### PR TITLE
修复发行版构建问题

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1098,7 +1098,7 @@ packages:
       path: media_kit
       ref: "version_1.2.5"
       resolved-ref: bc999bf181ddf12d60891f76e41359e4177b93a7
-      url: "https://github.com/furrybluelan/media-kit.git"
+      url: "https://github.com/media-kit/media-kit.git"
     source: git
     version: "1.1.11"
   media_kit_libs_android_video:
@@ -1107,7 +1107,7 @@ packages:
       path: "libs/android/media_kit_libs_android_video"
       ref: "version_1.2.5"
       resolved-ref: bc999bf181ddf12d60891f76e41359e4177b93a7
-      url: "https://github.com/furrybluelan/media-kit.git"
+      url: "https://github.com/media-kit/media-kit.git"
     source: git
     version: "1.3.7"
   media_kit_libs_ios_video:
@@ -1140,7 +1140,7 @@ packages:
       path: "libs/universal/media_kit_libs_video"
       ref: "version_1.2.5"
       resolved-ref: bc999bf181ddf12d60891f76e41359e4177b93a7
-      url: "https://github.com/furrybluelan/media-kit.git"
+      url: "https://github.com/media-kit/media-kit.git"
     source: git
     version: "1.0.5"
   media_kit_libs_windows_video:
@@ -1149,7 +1149,7 @@ packages:
       path: "libs/windows/media_kit_libs_windows_video"
       ref: "version_1.2.5"
       resolved-ref: bc999bf181ddf12d60891f76e41359e4177b93a7
-      url: "https://github.com/furrybluelan/media-kit.git"
+      url: "https://github.com/media-kit/media-kit.git"
     source: git
     version: "1.0.10"
   media_kit_native_event_loop:
@@ -1158,7 +1158,7 @@ packages:
       path: media_kit_native_event_loop
       ref: "version_1.2.5"
       resolved-ref: bc999bf181ddf12d60891f76e41359e4177b93a7
-      url: "https://github.com/furrybluelan/media-kit.git"
+      url: "https://github.com/media-kit/media-kit.git"
     source: git
     version: "1.0.9"
   media_kit_video:
@@ -1167,7 +1167,7 @@ packages:
       path: media_kit_video
       ref: "version_1.2.5"
       resolved-ref: bc999bf181ddf12d60891f76e41359e4177b93a7
-      url: "https://github.com/furrybluelan/media-kit.git"
+      url: "https://github.com/media-kit/media-kit.git"
     source: git
     version: "1.2.5"
   menu_base:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -109,7 +109,7 @@ dependencies:
     git:
       url: https://github.com/media-kit/media-kit.git
       path: media_kit_video
-      ref: version_1.3.1
+      ref: d310049f24196250d876efb02b9ff56fa9ef5068
   media_kit_libs_video: 1.0.7
 
   # 媒体通知
@@ -242,32 +242,32 @@ dependency_overrides:
     git:
       url: https://github.com/media-kit/media-kit.git
       path: media_kit
-      ref: version_1.3.1
+      ref: d310049f24196250d876efb02b9ff56fa9ef5068
   media_kit_video:
     git:
       url: https://github.com/media-kit/media-kit.git
       path: media_kit_video
-      ref: version_1.3.1
+      ref: d310049f24196250d876efb02b9ff56fa9ef5068
   media_kit_libs_video:
     git:
       url: https://github.com/media-kit/media-kit.git
       path: libs/universal/media_kit_libs_video
-      ref: version_1.3.1
+      ref: d310049f24196250d876efb02b9ff56fa9ef5068
   media_kit_native_event_loop:
     git:
       url: https://github.com/media-kit/media-kit.git
       path: media_kit_native_event_loop
-      ref: version_1.3.1
+      ref: d310049f24196250d876efb02b9ff56fa9ef5068
   media_kit_libs_android_video:
     git:
       url: https://github.com/media-kit/media-kit.git
       path: libs/android/media_kit_libs_android_video
-      ref: version_1.3.1
+      ref: d310049f24196250d876efb02b9ff56fa9ef5068
   media_kit_libs_windows_video:
     git:
       url: https://github.com/media-kit/media-kit.git
       path: libs/windows/media_kit_libs_windows_video
-      ref: version_1.3.1
+      ref: d310049f24196250d876efb02b9ff56fa9ef5068
   font_awesome_flutter: 10.9.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -240,32 +240,32 @@ dependency_overrides:
   rxdart: ^0.28.0
   media_kit:
     git:
-      url: https://github.com/furrybluelan/media-kit.git
+      url: https://github.com/media-kit/media-kit.git
       path: media_kit
       ref: version_1.2.5
   media_kit_video:
     git:
-      url: https://github.com/furrybluelan/media-kit.git
+      url: https://github.com/media-kit/media-kit.git
       path: media_kit_video
       ref: version_1.2.5
   media_kit_libs_video:
     git:
-      url: https://github.com/furrybluelan/media-kit.git
+      url: https://github.com/media-kit/media-kit.git
       path: libs/universal/media_kit_libs_video
       ref: version_1.2.5
   media_kit_native_event_loop:
     git:
-      url: https://github.com/furrybluelan/media-kit.git
+      url: https://github.com/media-kit/media-kit.git
       path: media_kit_native_event_loop
       ref: version_1.2.5
   media_kit_libs_android_video:
     git:
-      url: https://github.com/furrybluelan/media-kit.git
+      url: https://github.com/media-kit/media-kit.git
       path: libs/android/media_kit_libs_android_video
       ref: version_1.2.5
   media_kit_libs_windows_video:
     git:
-      url: https://github.com/furrybluelan/media-kit.git
+      url: https://github.com/media-kit/media-kit.git
       path: libs/windows/media_kit_libs_windows_video
       ref: version_1.2.5
   font_awesome_flutter: 10.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -107,9 +107,9 @@ dependencies:
   # media_kit_video: ^1.2.5 # For video rendering.
   media_kit_video:
     git:
-      url: https://github.com/media-kit/media-kit.git
+      url: https://github.com/Li2548/media-kit.git
       path: media_kit_video
-      ref: d310049f24196250d876efb02b9ff56fa9ef5068
+      ref: 3220b8e352ab60e451d0e0b9040265d6e1d0c5d5
   media_kit_libs_video: 1.0.7
 
   # 媒体通知
@@ -240,34 +240,34 @@ dependency_overrides:
   rxdart: ^0.28.0
   media_kit:
     git:
-      url: https://github.com/media-kit/media-kit.git
+      url: https://github.com/Li2548/media-kit.git
       path: media_kit
-      ref: d310049f24196250d876efb02b9ff56fa9ef5068
+      ref: 3220b8e352ab60e451d0e0b9040265d6e1d0c5d5
   media_kit_video:
     git:
-      url: https://github.com/media-kit/media-kit.git
+      url: https://github.com/Li2548/media-kit.git
       path: media_kit_video
-      ref: d310049f24196250d876efb02b9ff56fa9ef5068
+      ref: 3220b8e352ab60e451d0e0b9040265d6e1d0c5d5
   media_kit_libs_video:
     git:
-      url: https://github.com/media-kit/media-kit.git
+      url: https://github.com/Li2548/media-kit.git
       path: libs/universal/media_kit_libs_video
-      ref: d310049f24196250d876efb02b9ff56fa9ef5068
+      ref: 3220b8e352ab60e451d0e0b9040265d6e1d0c5d5
   media_kit_native_event_loop:
     git:
-      url: https://github.com/media-kit/media-kit.git
+      url: https://github.com/Li2548/media-kit.git
       path: media_kit_native_event_loop
-      ref: version_1.2.5
+      ref: 3220b8e352ab60e451d0e0b9040265d6e1d0c5d5
   media_kit_libs_android_video:
     git:
-      url: https://github.com/media-kit/media-kit.git
+      url: https://github.com/Li2548/media-kit.git
       path: libs/android/media_kit_libs_android_video
-      ref: d310049f24196250d876efb02b9ff56fa9ef5068
+      ref: 3220b8e352ab60e451d0e0b9040265d6e1d0c5d5
   media_kit_libs_windows_video:
     git:
-      url: https://github.com/media-kit/media-kit.git
+      url: https://github.com/Li2548/media-kit.git
       path: libs/windows/media_kit_libs_windows_video
-      ref: d310049f24196250d876efb02b9ff56fa9ef5068
+      ref: 3220b8e352ab60e451d0e0b9040265d6e1d0c5d5
   font_awesome_flutter: 10.9.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -103,14 +103,14 @@ dependencies:
   encrypt: ^5.0.3
 
   # 视频播放器
-  media_kit: 1.1.11 # Primary package.
+  media_kit: 1.2.1 # Primary package.
   # media_kit_video: ^1.2.5 # For video rendering.
   media_kit_video:
     git:
       url: https://github.com/media-kit/media-kit.git
       path: media_kit_video
-      ref: version_1.2.5
-  media_kit_libs_video: 1.0.5
+      ref: version_1.3.1
+  media_kit_libs_video: 1.0.7
 
   # 媒体通知
   audio_service: ^0.18.15
@@ -242,32 +242,32 @@ dependency_overrides:
     git:
       url: https://github.com/media-kit/media-kit.git
       path: media_kit
-      ref: version_1.2.5
+      ref: version_1.3.1
   media_kit_video:
     git:
       url: https://github.com/media-kit/media-kit.git
       path: media_kit_video
-      ref: version_1.2.5
+      ref: version_1.3.1
   media_kit_libs_video:
     git:
       url: https://github.com/media-kit/media-kit.git
       path: libs/universal/media_kit_libs_video
-      ref: version_1.2.5
+      ref: version_1.3.1
   media_kit_native_event_loop:
     git:
       url: https://github.com/media-kit/media-kit.git
       path: media_kit_native_event_loop
-      ref: version_1.2.5
+      ref: version_1.3.1
   media_kit_libs_android_video:
     git:
       url: https://github.com/media-kit/media-kit.git
       path: libs/android/media_kit_libs_android_video
-      ref: version_1.2.5
+      ref: version_1.3.1
   media_kit_libs_windows_video:
     git:
       url: https://github.com/media-kit/media-kit.git
       path: libs/windows/media_kit_libs_windows_video
-      ref: version_1.2.5
+      ref: version_1.3.1
   font_awesome_flutter: 10.9.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -80,7 +80,7 @@ dependencies:
   # extended_nested_scroll_view: ^6.2.1
   extended_nested_scroll_view:
     git:
-      url: https://github.com/furrybluelan/extended_nested_scroll_view.git
+      url: https://github.com/bggRGjQaUbCoE/extended_nested_scroll_view.git
       ref: mod
   # 上拉加载
   # loading_more_list: ^7.1.0
@@ -91,7 +91,7 @@ dependencies:
   # material_design_icons_flutter: ^7.0.7296
   material_design_icons_flutter:
     git:
-      url: https://github.com/furrybluelan/material_design_icons_flutter.git
+      url: https://github.com/bggRGjQaUbCoE/material_design_icons_flutter.git
       ref: const
   # toast
   flutter_smart_dialog: ^4.9.8+5
@@ -122,7 +122,7 @@ dependencies:
   # universal_platform: ^1.1.0
   auto_orientation:
     git:
-      url: https://github.com/furrybluelan/auto_orientation.git
+      url: https://github.com/bggRGjQaUbCoE/auto_orientation.git
       ref: master
   protobuf: ^5.0.0
   # animations: ^2.0.11
@@ -153,7 +153,7 @@ dependencies:
   # floating: ^3.0.0
   floating:
     git:
-      url: https://github.com/furrybluelan/floating.git
+      url: https://github.com/bggRGjQaUbCoE/floating.git
       ref: version-3
   # html解析
   html: ^0.15.4
@@ -175,7 +175,7 @@ dependencies:
   # chat_bottom_container: ^0.2.0
   chat_bottom_container:
     git:
-      url: https://github.com/furrybluelan/flutter_chat_packages.git
+      url: https://github.com/bggRGjQaUbCoE/flutter_chat_packages.git
       ref: main
       path: packages/chat_bottom_container
   image_picker: ^1.1.2
@@ -199,7 +199,7 @@ dependencies:
   re_highlight: ^0.0.3
   flutter_sortable_wrap:
     git:
-      url: https://github.com/furrybluelan/flutter_sortable_wrap.git
+      url: https://github.com/bggRGjQaUbCoE/flutter_sortable_wrap.git
       ref: master
   crclib: ^3.0.0
   web_socket_channel: ^3.0.3
@@ -207,14 +207,14 @@ dependencies:
   # window_manager: ^0.5.1
   window_manager:
     git:
-      url: https://github.com/furrybluelan/window_manager.git
+      url: https://github.com/bggRGjQaUbCoE/window_manager.git
       path: packages/window_manager
       ref: main
   tray_manager: ^0.5.1
   file_picker: ^10.3.3
   super_sliver_list:
     git:
-      url: https://github.com/furrybluelan/super_sliver_list.git
+      url: https://github.com/bggRGjQaUbCoE/super_sliver_list.git
       ref: mod
 
   vector_math: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -257,7 +257,7 @@ dependency_overrides:
     git:
       url: https://github.com/media-kit/media-kit.git
       path: media_kit_native_event_loop
-      ref: d310049f24196250d876efb02b9ff56fa9ef5068
+      ref: version_1.2.5
   media_kit_libs_android_video:
     git:
       url: https://github.com/media-kit/media-kit.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -107,7 +107,7 @@ dependencies:
   # media_kit_video: ^1.2.5 # For video rendering.
   media_kit_video:
     git:
-      url: https://github.com/furrybluelan/media-kit.git
+      url: https://github.com/media-kit/media-kit.git
       path: media_kit_video
       ref: version_1.2.5
   media_kit_libs_video: 1.0.5


### PR DESCRIPTION
实际上是你并未fork所有支持库，导致无法编译。本fork修改了编译用的文件一个。
但由于配置不当（如下），ios发行版未能编译。鬼知道为何linux和mac也不行。
Building a deployable iOS app requires a selected Development Team with a Provisioning Profile. Please ensure that a Development Team is selected by: