### PR TITLE
更新build.py

### DIFF
--- a/build.py
+++ b/build.py
@@ -327,6 +327,7 @@ def git_revert(commit_hash: str,
         run(["git", "config", "user.email", "ci@example.com"],cwd=cwd)
         run(["git", "stash"],cwd=cwd, check=False)
         run(["git", "revert", commit_hash, "--no-edit"],cwd=cwd)
+        run(["git", "reset", "--soft", "HEAD~1"],cwd=cwd)
         run(["git", "stash", "pop"], cwd=cwd, check=False)
         ok(finished_message)
     except subprocess.CalledProcessError:


### PR DESCRIPTION
修复了build.py中git_revert函数，通过补上git reset命令。
这样Android编译就能过了。
检查见https://github.com/Li2548/PiliSuper/pull/27 因而不重复检查。