### PR TITLE
fix(build): consolidate Telegram artifacts into media group

### DIFF
--- a/tool/build/notify_telegram.py
+++ b/tool/build/notify_telegram.py
@@ -56,6 +56,8 @@ def find_artifacts(output_dir: Path) -> list[Artifact]:
     for path in sorted(output_dir.rglob("*"), key=lambda item: item.name.lower()):
         if not path.is_file() or not path.name.lower().endswith(ARTIFACT_SUFFIXES):
             continue
+        if not path.name.lower().startswith("pilisuper"):
+            continue
         size = path.stat().st_size
         identity = (file_digest(path), size)
         if identity in seen:
@@ -213,6 +215,61 @@ class TelegramClient:
         with urllib.request.urlopen(request, timeout=self.timeout) as response:
             self._response_result(response.read())
 
+    def send_media_group(self, artifacts: list[Artifact], caption: str) -> None:
+        if not artifacts:
+            return
+
+        if len(artifacts) > 10:
+            raise ValueError(f"Telegram media groups support max 10 items, got {len(artifacts)}")
+
+        media_items = []
+        for idx, artifact in enumerate(artifacts):
+            media_item = {
+                "type": "document",
+                "media": f"attach://file{idx}",
+            }
+            if idx == 0:
+                media_item["caption"] = truncate(caption, 1024)
+                media_item["parse_mode"] = "HTML"
+            media_items.append(media_item)
+
+        boundary = f"PiliSuper-{uuid.uuid4().hex}"
+        fields = {
+            "chat_id": self.chat_id,
+            "media": json.dumps(media_items),
+        }
+        if self.topic_id:
+            fields["message_thread_id"] = self.topic_id
+
+        body = bytearray()
+        for name, value in fields.items():
+            body.extend(f"--{boundary}\r\n".encode())
+            body.extend(
+                f'Content-Disposition: form-data; name="{name}"\r\n\r\n{value}\r\n'.encode()
+            )
+
+        for idx, artifact in enumerate(artifacts):
+            content_type = mimetypes.guess_type(artifact.name)[0] or "application/octet-stream"
+            body.extend(f"--{boundary}\r\n".encode())
+            body.extend(
+                (
+                    f'Content-Disposition: form-data; name="file{idx}"; '
+                    f'filename="{artifact.name}"\r\nContent-Type: {content_type}\r\n\r\n'
+                ).encode()
+            )
+            body.extend(artifact.path.read_bytes())
+            body.extend(b"\r\n")
+
+        body.extend(f"--{boundary}--\r\n".encode())
+
+        request = urllib.request.Request(
+            f"{self.base_url}/sendMediaGroup",
+            data=bytes(body),
+            headers={"Content-Type": f"multipart/form-data; boundary={boundary}"},
+        )
+        with urllib.request.urlopen(request, timeout=self.timeout) as response:
+            self._response_result(response.read())
+
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
@@ -262,12 +319,13 @@ def main() -> int:
         release_tag=args.release_tag,
     )
     try:
-        message_id = client.send_message(message)
-        if args.release_tag:
-            client.pin_message(message_id)
-        for artifact in uploadable:
-            print(f"Sending {artifact.name} ({format_size(artifact.size)})")
-            client.send_document(artifact)
+        if uploadable:
+            print(f"Sending {len(uploadable)} artifact(s) as media group")
+            client.send_media_group(uploadable, message)
+        else:
+            message_id = client.send_message(message)
+            if args.release_tag:
+                client.pin_message(message_id)
     except (OSError, RuntimeError, urllib.error.URLError) as error:
         print(f"Telegram notification failed: {error}", file=sys.stderr)
         return 1

--- a/tool/build/tests/test_build_scripts.py
+++ b/tool/build/tests/test_build_scripts.py
@@ -268,6 +268,75 @@ class TelegramNotifyTests(unittest.TestCase):
         self.assertIn("这是一个 Release", message)
         self.assertIn("v2.1.0", message)
 
+    def test_find_artifacts_only_matches_pilisuper_prefix(self):
+        with tempfile.TemporaryDirectory() as temp:
+            output = Path(temp)
+            (output / "PiliSuper.exe").write_bytes(b"content1")
+            (output / "pilisuper_android.apk").write_bytes(b"content2")
+            (output / "PILISUPER.dmg").write_bytes(b"content3")
+            (output / "piliplus.exe").write_bytes(b"excluded")
+            (output / "other.zip").write_bytes(b"excluded")
+
+            artifacts = notify_telegram.find_artifacts(output)
+
+            names = [item.name for item in artifacts]
+            self.assertIn("PiliSuper.exe", names)
+            self.assertIn("pilisuper_android.apk", names)
+            self.assertIn("PILISUPER.dmg", names)
+            self.assertEqual(len(names), 3)
+
+    def test_send_media_group_calls_telegram_api_with_documents(self):
+        with tempfile.TemporaryDirectory() as temp:
+            file_a = Path(temp) / "a.apk"
+            file_b = Path(temp) / "b.ipa"
+            file_a.write_bytes(b"content_a")
+            file_b.write_bytes(b"content_b")
+
+            client = notify_telegram.TelegramClient("fake_token", "fake_chat", None)
+            artifacts = [
+                notify_telegram.Artifact(file_a, "a.apk", 1024),
+                notify_telegram.Artifact(file_b, "b.ipa", 2048),
+            ]
+
+            with patch("urllib.request.urlopen") as urlopen_mock:
+                urlopen_mock.return_value.__enter__.return_value.read.return_value = (
+                    b'{"ok": true, "result": [{"message_id": 123}]}'
+                )
+                client.send_media_group(artifacts, caption="Test caption")
+
+            call_args = urlopen_mock.call_args
+            self.assertIn("sendMediaGroup", call_args[0][0].full_url)
+
+    def test_main_sends_media_group_with_build_message_caption(self):
+        with tempfile.TemporaryDirectory() as temp:
+            output = Path(temp)
+            (output / "PiliSuper.apk").write_bytes(b"x" * 1024)
+
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "TELEGRAM_BOT_TOKEN": "test_token",
+                        "TELEGRAM_CHAT_ID": "test_chat",
+                        "GITHUB_REPOSITORY": "owner/repo",
+                        "GITHUB_SHA": "abc123",
+                    },
+                ),
+                patch.object(
+                    sys, "argv", ["notify_telegram.py", "--output", str(output)]
+                ),
+                patch("urllib.request.urlopen") as urlopen_mock,
+            ):
+                urlopen_mock.return_value.__enter__.return_value.read.return_value = (
+                    b'{"ok": true, "result": [{"message_id": 123}]}'
+                )
+                notify_telegram.main()
+
+                calls = [call[0][0].full_url for call in urlopen_mock.call_args_list]
+                self.assertEqual(len([c for c in calls if "sendMediaGroup" in c]), 1)
+                self.assertEqual(len([c for c in calls if "sendMessage" in c]), 0)
+                self.assertEqual(len([c for c in calls if "sendDocument" in c]), 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 变更内容

### 1. 白名单匹配 - 仅保留 PiliSuper 开头的文件
- 修改 `find_artifacts()` 为白名单模式：只匹配以 `pilisuper` 开头的文件（不区分大小写）
- 自动排除 `piliplus.exe`、`other.zip` 等不符合命名规则的文件
- 支持 `PiliSuper.exe`、`pilisuper_android.apk`、`PILISUPER.dmg` 等变体

### 2. 合并为单个 Telegram 媒体组
- 新增 `send_media_group()` 方法，使用 Telegram `sendMediaGroup` API
- 将 `build_message()` 构造的完整文本作为媒体组的 caption（放在第一个文件上）
- 替换原来的 "文本消息 + 逐个上传文件" 模式

### 3. 测试覆盖
- 添加 3 个新测试：
  - `test_find_artifacts_only_matches_pilisuper_prefix` - 验证白名单匹配
  - `test_send_media_group_calls_telegram_api_with_documents` - 验证 API 调用
  - `test_main_sends_media_group_with_build_message_caption` - 验证端到端行为
- 全部 20 个测试通过（17 个原有 + 3 个新增）

## 技术细节

**API 变化：**
- 使用 `sendMediaGroup` 替代 `sendMessage` + 多次 `sendDocument`
- Caption 限制为 1024 字符（已通过 `truncate` 处理）
- 媒体组最多支持 10 个文件（超过会抛出清晰的错误）

## Breaking Changes

⚠️ **Release 标签的 pin 功能在媒体组模式下被移除**
- 原因：Telegram API 的 `sendMediaGroup` 返回消息数组而非单个 `message_id`
- 当没有可上传文件时，仍发送纯文本消息（保留 pin 功能）

## 验证结果

- ✅ 所有测试通过（20/20）
- ✅ Python 语法检查通过
- ✅ 无空白错误
- ✅ 纯代码行数 292（在 350 行限制内）

Refs: #issue