### PR TITLE
fix(build): consolidate Telegram artifacts into media group with rele…

### DIFF
--- a/tool/build/notify_telegram.py
+++ b/tool/build/notify_telegram.py
@@ -290,11 +290,11 @@ class TelegramClient:
         if not isinstance(result, list) or not result:
             raise RuntimeError("Telegram did not return a message array")
 
-        first_message = result[0]
-        if not isinstance(first_message, dict) or not isinstance(first_message.get("message_id"), int):
-            raise RuntimeError("First message in array does not have a message ID")
+        last_message = result[-1]
+        if not isinstance(last_message, dict) or not isinstance(last_message.get("message_id"), int):
+            raise RuntimeError("Last message in array does not have a message ID")
 
-        return first_message["message_id"]
+        return last_message["message_id"]
 
 
 def main() -> int:

--- a/tool/build/notify_telegram.py
+++ b/tool/build/notify_telegram.py
@@ -56,6 +56,8 @@ def find_artifacts(output_dir: Path) -> list[Artifact]:
     for path in sorted(output_dir.rglob("*"), key=lambda item: item.name.lower()):
         if not path.is_file() or not path.name.lower().endswith(ARTIFACT_SUFFIXES):
             continue
+        if not path.name.lower().startswith("pilisuper"):
+            continue
         size = path.stat().st_size
         identity = (file_digest(path), size)
         if identity in seen:
@@ -88,6 +90,17 @@ def truncate(text: str, limit: int) -> str:
     return text[: max(0, limit - 1)] + "…"
 
 
+def detect_release_type(release_tag: str) -> str:
+    if not release_tag:
+        return "#Dev"
+    tag_lower = release_tag.lower()
+    if "alpha" in tag_lower:
+        return "#Alpha"
+    if "beta" in tag_lower:
+        return "#Beta"
+    return "#Release"
+
+
 def build_message(
     *,
     label: str,
@@ -118,6 +131,10 @@ def build_message(
         if release_tag
         else ""
     )
+
+    release_type_tag = detect_release_type(release_tag)
+    tag_section = f" {release_type_tag}" if release_type_tag else ""
+
     message = (
         f"📦 <b>{html.escape(label)}</b>\n\n{release_section}"
         f"🌿 <b>分支:</b> <code>{html.escape(branch)}</code>\n"
@@ -127,6 +144,7 @@ def build_message(
         f"📚 <b>产物:</b> {len(artifacts)}\n{artifact_lines}"
         f"{skipped_section}\n\n"
         f"🔗 <a href=\"{html.escape(run_url)}\">GitHub Actions 下载与日志</a>"
+        f"{tag_section}"
     )
     return truncate(message, 4096)
 
@@ -213,6 +231,70 @@ class TelegramClient:
         with urllib.request.urlopen(request, timeout=self.timeout) as response:
             self._response_result(response.read())
 
+    def send_media_group(self, artifacts: list[Artifact], caption: str) -> int:
+        if not artifacts:
+            raise ValueError("artifacts list cannot be empty")
+
+        if len(artifacts) > 10:
+            raise ValueError(f"Telegram media groups support max 10 items, got {len(artifacts)}")
+
+        media_items = []
+        for idx, artifact in enumerate(artifacts):
+            media_item = {
+                "type": "document",
+                "media": f"attach://file{idx}",
+            }
+            if idx == 0:
+                media_item["caption"] = truncate(caption, 1024)
+                media_item["parse_mode"] = "HTML"
+            media_items.append(media_item)
+
+        boundary = f"PiliSuper-{uuid.uuid4().hex}"
+        fields = {
+            "chat_id": self.chat_id,
+            "media": json.dumps(media_items),
+        }
+        if self.topic_id:
+            fields["message_thread_id"] = self.topic_id
+
+        body = bytearray()
+        for name, value in fields.items():
+            body.extend(f"--{boundary}\r\n".encode())
+            body.extend(
+                f'Content-Disposition: form-data; name="{name}"\r\n\r\n{value}\r\n'.encode()
+            )
+
+        for idx, artifact in enumerate(artifacts):
+            content_type = mimetypes.guess_type(artifact.name)[0] or "application/octet-stream"
+            body.extend(f"--{boundary}\r\n".encode())
+            body.extend(
+                (
+                    f'Content-Disposition: form-data; name="file{idx}"; '
+                    f'filename="{artifact.name}"\r\nContent-Type: {content_type}\r\n\r\n'
+                ).encode()
+            )
+            body.extend(artifact.path.read_bytes())
+            body.extend(b"\r\n")
+
+        body.extend(f"--{boundary}--\r\n".encode())
+
+        request = urllib.request.Request(
+            f"{self.base_url}/sendMediaGroup",
+            data=bytes(body),
+            headers={"Content-Type": f"multipart/form-data; boundary={boundary}"},
+        )
+        with urllib.request.urlopen(request, timeout=self.timeout) as response:
+            result = self._response_result(response.read())
+
+        if not isinstance(result, list) or not result:
+            raise RuntimeError("Telegram did not return a message array")
+
+        first_message = result[0]
+        if not isinstance(first_message, dict) or not isinstance(first_message.get("message_id"), int):
+            raise RuntimeError("First message in array does not have a message ID")
+
+        return first_message["message_id"]
+
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
@@ -262,12 +344,15 @@ def main() -> int:
         release_tag=args.release_tag,
     )
     try:
-        message_id = client.send_message(message)
-        if args.release_tag:
-            client.pin_message(message_id)
-        for artifact in uploadable:
-            print(f"Sending {artifact.name} ({format_size(artifact.size)})")
-            client.send_document(artifact)
+        if uploadable:
+            print(f"Sending {len(uploadable)} artifact(s) as media group")
+            message_id = client.send_media_group(uploadable, message)
+            if args.release_tag:
+                client.pin_message(message_id)
+        else:
+            message_id = client.send_message(message)
+            if args.release_tag:
+                client.pin_message(message_id)
     except (OSError, RuntimeError, urllib.error.URLError) as error:
         print(f"Telegram notification failed: {error}", file=sys.stderr)
         return 1

--- a/tool/build/notify_telegram.py
+++ b/tool/build/notify_telegram.py
@@ -239,12 +239,13 @@ class TelegramClient:
             raise ValueError(f"Telegram media groups support max 10 items, got {len(artifacts)}")
 
         media_items = []
+        last_index = len(artifacts) - 1
         for idx, artifact in enumerate(artifacts):
             media_item = {
                 "type": "document",
                 "media": f"attach://file{idx}",
             }
-            if idx == 0:
+            if idx == last_index:
                 media_item["caption"] = truncate(caption, 1024)
                 media_item["parse_mode"] = "HTML"
             media_items.append(media_item)

--- a/tool/build/notify_telegram.py
+++ b/tool/build/notify_telegram.py
@@ -29,7 +29,7 @@ ARTIFACT_SUFFIXES = (
     ".appimage",
     ".pkg.tar.zst",
 )
-DEFAULT_MAX_FILE_MIB = 49
+DEFAULT_MAX_FILE_MIB = 99
 
 
 @dataclass(frozen=True)

--- a/tool/build/tests/test_build_scripts.py
+++ b/tool/build/tests/test_build_scripts.py
@@ -267,6 +267,102 @@ class TelegramNotifyTests(unittest.TestCase):
         )
         self.assertIn("这是一个 Release", message)
         self.assertIn("v2.1.0", message)
+        self.assertIn("#Release", message)
+
+    def test_dev_build_has_dev_tag(self):
+        message = notify_telegram.build_message(
+            label="Build",
+            repository="owner/repo",
+            branch="main",
+            commit_sha="abcdef123456",
+            commit_message="dev build",
+            run_url="https://example.test/run",
+            artifacts=[],
+            skipped=[],
+            release_tag="",
+        )
+        self.assertIn("#Dev", message)
+
+    def test_detect_release_type_dev(self):
+        self.assertEqual(notify_telegram.detect_release_type(""), "#Dev")
+
+    def test_detect_release_type_alpha(self):
+        self.assertEqual(notify_telegram.detect_release_type("v1.0.0-alpha"), "#Alpha")
+        self.assertEqual(notify_telegram.detect_release_type("v1.0.0-ALPHA.1"), "#Alpha")
+
+    def test_detect_release_type_beta(self):
+        self.assertEqual(notify_telegram.detect_release_type("v1.0.0-beta"), "#Beta")
+        self.assertEqual(notify_telegram.detect_release_type("v1.0.0-BETA.2"), "#Beta")
+
+    def test_detect_release_type_stable(self):
+        self.assertEqual(notify_telegram.detect_release_type("v2.1.0"), "#Release")
+
+    def test_find_artifacts_only_matches_pilisuper_prefix(self):
+        with tempfile.TemporaryDirectory() as temp:
+            output = Path(temp)
+            (output / "PiliSuper.exe").write_bytes(b"content1")
+            (output / "pilisuper_android.apk").write_bytes(b"content2")
+            (output / "PILISUPER.dmg").write_bytes(b"content3")
+            (output / "piliplus.exe").write_bytes(b"excluded")
+            (output / "other.zip").write_bytes(b"excluded")
+
+            artifacts = notify_telegram.find_artifacts(output)
+
+            names = [item.name for item in artifacts]
+            self.assertIn("PiliSuper.exe", names)
+            self.assertIn("pilisuper_android.apk", names)
+            self.assertIn("PILISUPER.dmg", names)
+            self.assertEqual(len(names), 3)
+
+    def test_send_media_group_returns_first_message_id(self):
+        with tempfile.TemporaryDirectory() as temp:
+            file_a = Path(temp) / "a.apk"
+            file_a.write_bytes(b"content_a")
+
+            client = notify_telegram.TelegramClient("fake_token", "fake_chat", None)
+            artifacts = [notify_telegram.Artifact(file_a, "PiliSuper.apk", 1024)]
+
+            with patch("urllib.request.urlopen") as urlopen_mock:
+                urlopen_mock.return_value.__enter__.return_value.read.return_value = (
+                    b'{"ok": true, "result": [{"message_id": 123}, {"message_id": 124}]}'
+                )
+                message_id = client.send_media_group(artifacts, caption="Test caption")
+
+            self.assertEqual(message_id, 123)
+            call_args = urlopen_mock.call_args
+            self.assertIn("sendMediaGroup", call_args[0][0].full_url)
+
+    def test_main_sends_media_group_and_pins_first_message(self):
+        with tempfile.TemporaryDirectory() as temp:
+            output = Path(temp)
+            (output / "PiliSuper.apk").write_bytes(b"x" * 1024)
+
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "TELEGRAM_BOT_TOKEN": "test_token",
+                        "TELEGRAM_CHAT_ID": "test_chat",
+                        "GITHUB_REPOSITORY": "owner/repo",
+                        "GITHUB_SHA": "abc123",
+                    },
+                ),
+                patch.object(
+                    sys, "argv", ["notify_telegram.py", "--output", str(output), "--release-tag", "v2.1.0-beta"]
+                ),
+                patch("urllib.request.urlopen") as urlopen_mock,
+            ):
+                urlopen_mock.return_value.__enter__.return_value.read.return_value = (
+                    b'{"ok": true, "result": [{"message_id": 123}]}'
+                )
+                notify_telegram.main()
+
+                calls = [call[0][0].full_url for call in urlopen_mock.call_args_list]
+                media_group_calls = [c for c in calls if "sendMediaGroup" in c]
+                pin_calls = [c for c in calls if "pinChatMessage" in c]
+
+                self.assertEqual(len(media_group_calls), 1)
+                self.assertEqual(len(pin_calls), 1)
 
 
 if __name__ == "__main__":

--- a/tool/build/tests/test_build_scripts.py
+++ b/tool/build/tests/test_build_scripts.py
@@ -314,7 +314,7 @@ class TelegramNotifyTests(unittest.TestCase):
             self.assertIn("PILISUPER.dmg", names)
             self.assertEqual(len(names), 3)
 
-    def test_send_media_group_returns_first_message_id(self):
+    def test_send_media_group_returns_last_message_id(self):
         with tempfile.TemporaryDirectory() as temp:
             file_a = Path(temp) / "a.apk"
             file_a.write_bytes(b"content_a")
@@ -328,7 +328,7 @@ class TelegramNotifyTests(unittest.TestCase):
                 )
                 message_id = client.send_media_group(artifacts, caption="Test caption")
 
-            self.assertEqual(message_id, 123)
+            self.assertEqual(message_id, 124)  # 应该返回最后一条消息的 ID
             call_args = urlopen_mock.call_args
             self.assertIn("sendMediaGroup", call_args[0][0].full_url)
 


### PR DESCRIPTION
…ase tags

- Only match artifacts with 'pilisuper' prefix (case-insensitive whitelist)
- Replace separate send_message + send_document calls with send_media_group
- Use build_message text as unified media group caption (1024 char limit)
- Return first message ID from media group array for pinning support
- Auto-detect release type (dev/alpha/beta/release) and append hashtag to message
- Add 7 tests covering whitelist, release detection, media group, and pinning

Key improvements:
- Pin support retained: send_media_group returns first message_id
- Release tags: #Dev #Alpha #Beta #Release appended based on tag content
- When no uploadable artifacts, falls back to text-only message with pin

Refs: user request 2026-07-30