### PR TITLE
feat: android predictive back gesture support

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,7 +38,7 @@
     <application xmlns:tools="http://schemas.android.com/tools"
         android:name="${applicationName}"
         android:allowBackup="false"
-        android:enableOnBackInvokedCallback="false"
+        android:enableOnBackInvokedCallback="true"
         android:fullBackupContent="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/lib/utils/theme_utils.dart
+++ b/lib/utils/theme_utils.dart
@@ -146,7 +146,11 @@ abstract final class ThemeUtils {
       ),
       pageTransitionsTheme: const PageTransitionsTheme(
         builders: {
-          TargetPlatform.android: ZoomPageTransitionsBuilder(),
+          // PredictiveBackFullscreenPageTransitionsBuilder falls back to
+          // ZoomPageTransitionsBuilder below API 34, so behavior is
+          // unchanged on older devices.
+          TargetPlatform.android:
+              PredictiveBackFullscreenPageTransitionsBuilder(),
         },
       ),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -758,9 +758,9 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "version_4.7.2"
-      resolved-ref: "388fcb22ef24ac0a693949148d29fa6b4922159f"
-      url: "https://github.com/bggRGjQaUbCoE/getx.git"
+      ref: "feat/predictive-back"
+      resolved-ref: e982209b899d2b8d8dde3c2a4c27f21d224a0785
+      url: "https://github.com/FRBLanApps/getx.git"
     source: git
     version: "4.7.2"
   glob:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -106,8 +106,8 @@ dependencies:
       ref: v10.9.0
   get:
     git:
-      url: https://github.com/bggRGjQaUbCoE/getx.git
-      ref: version_4.7.2
+      url: https://github.com/FRBLanApps/getx.git
+      ref: feat/predictive-back
   hive_ce: ^2.19.3
   html: ^0.15.4
   http2: ^2.3.1


### PR DESCRIPTION
- AndroidManifest: enable OnBackInvokedCallback (inert below API 33)
- theme_utils: use PredictiveBackFullscreenPageTransitionsBuilder for MaterialPageRoute-style routes; falls back to ZoomPageTransitionsBuilder below API 34, zero behavior change for older devices
- pubspec: point get dependency to FRBLanApps/getx feat/predictive-back, where Transition.native on Android now delegates to the same builder