### PR TITLE
feat: 首页推荐流显示付费视频标签

### DIFF
--- a/lib/common/widgets/video_card/video_card_v.dart
+++ b/lib/common/widgets/video_card/video_card_v.dart
@@ -201,7 +201,7 @@ class VideoCardV extends StatelessWidget {
                   ),
                 if (videoItem.isPaid)
                   const PBadge(
-                    text: '付费视频',
+                    text: '充电专属',
                     isStack: false,
                     size: .small,
                     type: .error,

--- a/lib/common/widgets/video_card/video_card_v.dart
+++ b/lib/common/widgets/video_card/video_card_v.dart
@@ -199,6 +199,13 @@ class VideoCardV extends StatelessWidget {
                     size: .small,
                     type: .secondary,
                   ),
+                if (videoItem.isPaid)
+                  const PBadge(
+                    text: '付费视频',
+                    isStack: false,
+                    size: .small,
+                    type: .error,
+                  ),
                 Expanded(
                   flex: 1,
                   child: Text(

--- a/lib/models/home/rcmd/result.dart
+++ b/lib/models/home/rcmd/result.dart
@@ -48,6 +48,7 @@ class RcmdVideoItemAppModel extends BaseRcmdVideoItemModel {
         ? ThreePoint.fromJson(json['three_point_v2'])
         : null;
     desc = json['desc'];
+    chargingPay = json['charging_pay'];
   }
 }
 

--- a/lib/models/model_rec_video_item.dart
+++ b/lib/models/model_rec_video_item.dart
@@ -5,10 +5,13 @@ abstract class BaseRcmdVideoItemModel extends BaseVideoItemModel {
   String? goto;
   String? uri;
   String? rcmdReason;
+  Map<String, dynamic>? chargingPay;
 
   // app推荐专属
   int? param;
   String? pgcBadge;
+
+  bool get isPaid => chargingPay?['level'] != null;
 }
 
 class RcmdVideoItemModel extends BaseRcmdVideoItemModel {


### PR DESCRIPTION
- 在 BaseRcmdVideoItemModel 添加 chargingPay 字段和 isPaid getter
- RcmdVideoItemAppModel 解析 API 返回的 charging_pay 字段
- VideoCardV 在首页推荐视频卡片上显示 '付费视频' 红色标签
- 标签样式与现有 '充电专属' 标签一致 (PBadgeType.error)

Closes #95