### PR TITLE
feat: 投屏支持自选清晰度与默认画质设置

### DIFF
--- a/lib/models/common/video/video_quality.dart
+++ b/lib/models/common/video/video_quality.dart
@@ -23,4 +23,6 @@ enum VideoQuality {
   static final _codeMap = {for (final i in values) i.code: i};
 
   static VideoQuality fromCode(int code) => _codeMap[code]!;
+
+  static VideoQuality? tryFromCode(int code) => _codeMap[code];
 }

--- a/lib/pages/dlna/dlna_args.dart
+++ b/lib/pages/dlna/dlna_args.dart
@@ -1,0 +1,146 @@
+import 'package:PiliPlus/http/loading_state.dart';
+import 'package:PiliPlus/http/video.dart';
+import 'package:PiliPlus/models/common/video/video_quality.dart';
+import 'package:PiliPlus/models/video/play/url.dart';
+import 'package:PiliPlus/utils/video_utils.dart';
+import 'package:collection/collection.dart' show IterableExtension;
+
+/// 投屏可选清晰度
+class CastQuality {
+  const CastQuality(this.code, this.desc);
+
+  final int code;
+  final String desc;
+}
+
+typedef _CastSource = ({String url, int qn, List<CastQuality> qualities});
+
+/// 投屏页参数，同时负责按清晰度获取投屏地址
+class DlnaArgs {
+  DlnaArgs({
+    required this.cid,
+    required this.objectId,
+    required this.playurlType,
+    required this.url,
+    required this.qn,
+    required this.qualities,
+    this.title,
+  });
+
+  final int cid;
+
+  /// aid or epId
+  final int objectId;
+
+  /// ugc 1, pgc 2
+  final int playurlType;
+
+  final String? title;
+
+  /// 当前投屏地址
+  String url;
+
+  /// 当前清晰度
+  int qn;
+
+  /// 可选清晰度，为空表示该视频不支持切换
+  List<CastQuality> qualities;
+
+  String get qnDesc =>
+      qualities.firstWhereOrNull((e) => e.code == qn)?.desc ??
+      VideoQuality.tryFromCode(qn)?.desc ??
+      qn.toString();
+
+  static Future<LoadingState<DlnaArgs>> create({
+    required int cid,
+    required int objectId,
+    required int playurlType,
+    int? qn,
+    String? title,
+  }) async {
+    final res = await _request(
+      cid: cid,
+      objectId: objectId,
+      playurlType: playurlType,
+      qn: qn,
+    );
+    return switch (res) {
+      Success(:final response) => Success(
+        DlnaArgs(
+          cid: cid,
+          objectId: objectId,
+          playurlType: playurlType,
+          title: title,
+          url: response.url,
+          qn: response.qn,
+          qualities: response.qualities,
+        ),
+      ),
+      _ => res as LoadingState<DlnaArgs>,
+    };
+  }
+
+  /// 切换清晰度，成功后 [url] / [qn] 已更新
+  Future<LoadingState<DlnaArgs>> switchQuality(int newQn) async {
+    final res = await _request(
+      cid: cid,
+      objectId: objectId,
+      playurlType: playurlType,
+      qn: newQn,
+    );
+    if (res case Success(:final response)) {
+      url = response.url;
+      qn = response.qn;
+      if (response.qualities.isNotEmpty) {
+        qualities = response.qualities;
+      }
+      return Success(this);
+    }
+    return res as LoadingState<DlnaArgs>;
+  }
+
+  static Future<LoadingState<_CastSource>> _request({
+    required int cid,
+    required int objectId,
+    required int playurlType,
+    int? qn,
+  }) async {
+    final res = await VideoHttp.tvPlayUrl(
+      cid: cid,
+      objectId: objectId,
+      playurlType: playurlType,
+      qn: qn,
+    );
+    if (res case Success(:final response)) {
+      final first = response.durl?.firstOrNull;
+      if (first == null || first.playUrls.isEmpty) {
+        return const Error('不支持投屏');
+      }
+      return Success((
+        url: VideoUtils.getCdnUrl(first.playUrls),
+        qn: response.quality ?? qn ?? 80,
+        qualities: parseQualities(response),
+      ));
+    }
+    return res as LoadingState<_CastSource>;
+  }
+
+  /// 从 playurl 响应解析可选清晰度
+  static List<CastQuality> parseQualities(PlayUrlModel data) {
+    final codes = data.acceptQuality;
+    if (codes == null || codes.isEmpty) return const [];
+    final descList = data.acceptDesc;
+    return List.generate(codes.length, (index) {
+      final code = codes[index];
+      final desc = descList != null && index < descList.length
+          ? descList[index]
+          : null;
+      return CastQuality(
+        code,
+        desc is String && desc.isNotEmpty
+            ? desc
+            : VideoQuality.tryFromCode(code)?.desc ?? code.toString(),
+      );
+    });
+  }
+}

--- a/lib/pages/dlna/dlna_utils.dart
+++ b/lib/pages/dlna/dlna_utils.dart
@@ -1,0 +1,26 @@
+import 'package:dlna_dart/xmlParser.dart' show PositionParser;
+
+/// 从 GetPositionInfo 响应解析可恢复的播放进度（HH:MM:SS），
+/// 无有效进度（未实现 / 处于片头 / 解析失败）时返回 null
+String? parseSeekTime(String? xml) {
+  if (xml == null) return null;
+  try {
+    final parts = PositionParser(xml).RelTime.split(':');
+    if (parts.length != 3) {
+      return null;
+    }
+    final h = int.tryParse(parts[0]);
+    final m = int.tryParse(parts[1]);
+    final s = double.tryParse(parts[2]);
+    if (h == null || m == null || s == null) {
+      return null;
+    }
+    final seconds = h * 3600 + m * 60 + s.truncate();
+    if (seconds <= 0) {
+      return null;
+    }
+    return PositionParser.toStr(seconds);
+  } catch (_) {
+    return null;
+  }
+}

--- a/lib/pages/dlna/view.dart
+++ b/lib/pages/dlna/view.dart
@@ -65,35 +65,45 @@ class _DLNAPageState extends State<DLNAPage> {
   Future<void> _onSelectQuality(int qn) async {
     if (_isSwitchingQa || qn == _args.qn) return;
     _isSwitchingQa = true;
-    SmartDialog.showLoading();
-    final res = await _args.switchQuality(qn);
-    if (res case Success()) {
-      final device = _lastDevice;
-      // 重推前记录当前播放进度，重推后恢复
-      String? seekTime;
-      if (device != null) {
+    final prevUrl = _args.url;
+    final prevQn = _args.qn;
+    try {
+      SmartDialog.showLoading();
+      final res = await _args.switchQuality(qn);
+      if (res case Success()) {
+        final device = _lastDevice;
+        // 重推前记录当前播放进度，重推后恢复
+        String? seekTime;
+        if (device != null) {
+          try {
+            seekTime = parseSeekTime(
+              await device.position().timeout(const Duration(seconds: 5)),
+            );
+          } catch (_) {}
+        }
+        SmartDialog.dismiss();
+        // 重推成功才算切换成功，失败则回滚到切换前的地址与清晰度
         try {
-          seekTime = parseSeekTime(
-            await device.position().timeout(const Duration(seconds: 5)),
-          );
-        } catch (_) {}
+          await _rePush(device, seekTime);
+        } catch (_) {
+          _args
+            ..url = prevUrl
+            ..qn = prevQn;
+          if (!mounted) return;
+          setState(() {});
+          SmartDialog.showToast('切换清晰度失败，请重试');
+          return;
+        }
+        if (!mounted) return;
+        setState(() {});
+        SmartDialog.showToast('清晰度已切换为：${_args.qnDesc}');
+      } else {
+        SmartDialog.dismiss();
+        if (!mounted) return;
+        res.toast();
       }
-      SmartDialog.dismiss();
-      if (!mounted) {
-        // 页面已退出，仍完成重推以保持电视端播放
-        await _rePush(device, seekTime);
-        _isSwitchingQa = false;
-        return;
-      }
-      setState(() {});
-      SmartDialog.showToast('清晰度已切换为：${_args.qnDesc}');
-      await _rePush(device, seekTime);
+    } finally {
       _isSwitchingQa = false;
-    } else {
-      SmartDialog.dismiss();
-      _isSwitchingQa = false;
-      if (!mounted) return;
-      res.toast();
     }
   }
 

--- a/lib/pages/dlna/view.dart
+++ b/lib/pages/dlna/view.dart
@@ -6,6 +6,7 @@ import 'package:PiliPlus/common/widgets/scaffold/simple_scaffold.dart';
 import 'package:PiliPlus/common/widgets/view_sliver_safe_area.dart';
 import 'package:PiliPlus/http/loading_state.dart';
 import 'package:PiliPlus/pages/dlna/dlna_args.dart';
+import 'package:PiliPlus/pages/dlna/dlna_utils.dart';
 import 'package:dlna_dart/dlna.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
@@ -66,19 +67,52 @@ class _DLNAPageState extends State<DLNAPage> {
     _isSwitchingQa = true;
     SmartDialog.showLoading();
     final res = await _args.switchQuality(qn);
-    SmartDialog.dismiss();
-    _isSwitchingQa = false;
-    if (!mounted) return;
     if (res case Success()) {
+      final device = _lastDevice;
+      // 重推前记录当前播放进度，重推后恢复
+      String? seekTime;
+      if (device != null) {
+        try {
+          seekTime = parseSeekTime(
+            await device.position().timeout(const Duration(seconds: 5)),
+          );
+        } catch (_) {}
+      }
+      SmartDialog.dismiss();
+      if (!mounted) {
+        // 页面已退出，仍完成重推以保持电视端播放
+        await _rePush(device, seekTime);
+        _isSwitchingQa = false;
+        return;
+      }
       setState(() {});
       SmartDialog.showToast('清晰度已切换为：${_args.qnDesc}');
-      final device = _lastDevice;
-      if (device != null) {
-        await device.setUrl(_args.url, title: _args.title ?? '');
-        await device.play();
-      }
+      await _rePush(device, seekTime);
+      _isSwitchingQa = false;
     } else {
+      SmartDialog.dismiss();
+      _isSwitchingQa = false;
+      if (!mounted) return;
       res.toast();
+    }
+  }
+
+  Future<void> _rePush(DLNADevice? device, String? seekTime) async {
+    if (device == null) return;
+    await device.setUrl(_args.url, title: _args.title ?? '');
+    await device.play();
+    if (seekTime != null) {
+      // 部分设备就绪需要时间，seek 失败延时重试一次
+      for (final wait in const [
+        Duration(milliseconds: 500),
+        Duration(milliseconds: 1500),
+      ]) {
+        await Future.delayed(wait);
+        try {
+          await device.seek(seekTime).timeout(const Duration(seconds: 8));
+          break;
+        } catch (_) {}
+      }
     }
   }
 

--- a/lib/pages/dlna/view.dart
+++ b/lib/pages/dlna/view.dart
@@ -4,8 +4,11 @@ import 'package:PiliPlus/common/widgets/loading_widget/http_error.dart';
 import 'package:PiliPlus/common/widgets/loading_widget/loading_widget.dart';
 import 'package:PiliPlus/common/widgets/scaffold/simple_scaffold.dart';
 import 'package:PiliPlus/common/widgets/view_sliver_safe_area.dart';
+import 'package:PiliPlus/http/loading_state.dart';
+import 'package:PiliPlus/pages/dlna/dlna_args.dart';
 import 'package:dlna_dart/dlna.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:get/get.dart';
 
 class DLNAPage extends StatefulWidget {
@@ -18,11 +21,11 @@ class DLNAPage extends StatefulWidget {
 class _DLNAPageState extends State<DLNAPage> {
   final _searcher = DLNAManager();
   final Map<String, DLNADevice> _deviceList = {};
-  late final _url = Get.parameters['url']!;
-  late final _title = Get.parameters['title'];
+  late final _args = Get.arguments as DlnaArgs;
 
   Timer? _timer;
   bool _isSearching = false;
+  bool _isSwitchingQa = false;
   DLNADevice? _lastDevice;
   String? _lastDeviceKey;
 
@@ -58,6 +61,27 @@ class _DLNAPageState extends State<DLNAPage> {
     }
   }
 
+  Future<void> _onSelectQuality(int qn) async {
+    if (_isSwitchingQa || qn == _args.qn) return;
+    _isSwitchingQa = true;
+    SmartDialog.showLoading();
+    final res = await _args.switchQuality(qn);
+    SmartDialog.dismiss();
+    _isSwitchingQa = false;
+    if (!mounted) return;
+    if (res case Success()) {
+      setState(() {});
+      SmartDialog.showToast('清晰度已切换为：${_args.qnDesc}');
+      final device = _lastDevice;
+      if (device != null) {
+        await device.setUrl(_args.url, title: _args.title ?? '');
+        await device.play();
+      }
+    } else {
+      res.toast();
+    }
+  }
+
   @override
   void dispose() {
     _timer?.cancel();
@@ -75,6 +99,31 @@ class _DLNAPageState extends State<DLNAPage> {
       appBar: AppBar(
         title: const Text('投屏'),
         actions: [
+          if (_args.qualities.length > 1)
+            PopupMenuButton<int>(
+              tooltip: '清晰度',
+              initialValue: _args.qn,
+              onSelected: _onSelectQuality,
+              itemBuilder: (context) => _args.qualities
+                  .map(
+                    (item) => PopupMenuItem(
+                      value: item.code,
+                      child: Text(item.desc),
+                    ),
+                  )
+                  .toList(),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  spacing: 2,
+                  children: [
+                    Text(_args.qnDesc),
+                    const Icon(Icons.arrow_drop_down, size: 20),
+                  ],
+                ),
+              ),
+            ),
           IconButton(
             tooltip: '搜索',
             onPressed: _onSearch,
@@ -119,7 +168,7 @@ class _DLNAPageState extends State<DLNAPage> {
               _lastDevice = device;
               _lastDeviceKey = key;
               setState(() {});
-              await device.setUrl(_url, title: _title ?? '');
+              await device.setUrl(_args.url, title: _args.title ?? '');
               await device.play();
             },
           );

--- a/lib/pages/setting/models/video_settings.dart
+++ b/lib/pages/setting/models/video_settings.dart
@@ -133,6 +133,13 @@ List<SettingsModel> get videoSettings => [
     onTap: _showLiveCellularQaDialog,
   ),
   NormalModel(
+    title: '投屏默认画质',
+    leading: const Icon(Icons.cast_outlined),
+    getSubtitle: () =>
+        '当前画质：${Pref.defaultCastQa == -1 ? '跟随播放画质' : VideoQuality.fromCode(Pref.defaultCastQa).desc}',
+    onTap: _showCastQaDialog,
+  ),
+  NormalModel(
     title: '首选解码格式',
     leading: const Icon(Icons.movie_creation_outlined),
     getSubtitle: () =>
@@ -332,11 +339,31 @@ Future<void> _showLiveQaDialog(
   }
 }
 
-Future<void> _showLiveCellularQaDialog(
+Future<void> _showCastQaDialog(
   BuildContext context,
   VoidCallback setState,
 ) async {
   final res = await showDialog<int>(
+    context: context,
+    builder: (context) => SelectDialog<int>(
+      title: '投屏默认画质',
+      value: Pref.defaultCastQa,
+      values: [
+        (-1, '跟随播放画质'),
+        ...VideoQuality.values.map((e) => (e.code, e.desc)),
+      ],
+    ),
+  );
+  if (res != null) {
+    await GStorage.setting.put(SettingBoxKey.defaultCastQa, res);
+    setState();
+  }
+}
+
+Future<void> _showLiveCellularQaDialog(
+  BuildContext context,
+  VoidCallback setState,
+) async {  final res = await showDialog<int>(
     context: context,
     builder: (context) => SelectDialog<int>(
       title: '蜂窝网络直播默认画质',

--- a/lib/pages/video/controller.dart
+++ b/lib/pages/video/controller.dart
@@ -36,6 +36,7 @@ import 'package:PiliPlus/models_new/video/video_play_info/subtitle.dart';
 import 'package:PiliPlus/models_new/video/video_stein_edgeinfo/data.dart';
 import 'package:PiliPlus/pages/audio/view.dart';
 import 'package:PiliPlus/pages/common/publish/publish_route.dart';
+import 'package:PiliPlus/pages/dlna/dlna_args.dart';
 import 'package:PiliPlus/pages/search/widgets/search_text.dart';
 import 'package:PiliPlus/pages/sponsor_block/block_mixin.dart';
 import 'package:PiliPlus/pages/video/download_panel/view.dart';
@@ -1658,38 +1659,33 @@ class VideoDetailController extends GetxController
 
   @pragma('vm:notify-debugger-on-exception')
   Future<void> onCast() async {
+    String? title;
+    try {
+      if (isUgc) {
+        title = Get.find<UgcIntroController>(
+          tag: heroTag,
+        ).videoDetail.value.title;
+      } else {
+        title = Get.find<PgcIntroController>(
+          tag: heroTag,
+        ).videoDetail.value.title;
+      }
+    } catch (_) {}
+    if (kDebugMode) {
+      debugPrint(title);
+    }
+
     SmartDialog.showLoading();
-    final res = await VideoHttp.tvPlayUrl(
+    final res = await DlnaArgs.create(
       cid: cid.value,
       objectId: epId ?? aid,
       playurlType: epId != null ? 2 : 1,
-      qn: currentVideoQa.value?.code,
+      qn: Pref.defaultCastQa < 0 ? currentVideoQa.value?.code : Pref.defaultCastQa,
+      title: title,
     );
     SmartDialog.dismiss();
     if (res case Success(:final response)) {
-      final first = response.durl?.firstOrNull;
-      if (first == null || first.playUrls.isEmpty) {
-        SmartDialog.showToast('不支持投屏');
-        return;
-      }
-      final url = VideoUtils.getCdnUrl(first.playUrls);
-
-      String? title;
-      try {
-        if (isUgc) {
-          title = Get.find<UgcIntroController>(
-            tag: heroTag,
-          ).videoDetail.value.title;
-        } else {
-          title = Get.find<PgcIntroController>(
-            tag: heroTag,
-          ).videoDetail.value.title;
-        }
-      } catch (_) {}
-      if (kDebugMode) {
-        debugPrint(title);
-      }
-      Get.toNamed('/dlna', parameters: {'url': url, 'title': ?title});
+      Get.toNamed('/dlna', arguments: response);
     } else {
       res.toast();
     }

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -6,6 +6,7 @@ abstract final class SettingBoxKey {
       defaultVideoQaCellular = 'defaultVideoQaCellular',
       defaultAudioQa = 'defaultAudioQa',
       defaultAudioQaCellular = 'defaultAudioQaCellular',
+      defaultCastQa = 'defaultCastQa',
       autoPlayEnable = 'autoPlayEnable',
       fullScreenMode = 'fullScreenMode',
       preferCodecs = 'preferCodecs',

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -245,6 +245,10 @@ abstract final class Pref {
     defaultValue: AudioQuality.k192.code,
   );
 
+  /// 投屏默认画质，-1 表示跟随播放页画质
+  static int get defaultCastQa =>
+      _setting.get(SettingBoxKey.defaultCastQa, defaultValue: -1);
+
   static List<VideoDecodeFormatType> get preferCodecs {
     // TODO: remove next 2 version
     if (_setting.get('defaultDecode') case String codecStr) {


### PR DESCRIPTION
close #13

## 功能

实现 issue #13 请求的投屏自选清晰度功能，并补充默认投屏画质设置。

### 1. 投屏页内切换清晰度

- 投屏页 AppBar（刷新按钮旁）新增清晰度选择框，显示当前投屏画质（如「1080P 高清」），点击弹出可选清晰度列表
- 可选清晰度来自 `/x/tv/playurl` 响应的 `accept_quality` / `accept_description`，仅包含当前账号实际可用的档位
- 切换后按新 `qn` 重新取流；若设备正在投屏，自动向当前设备重推新流
- 若请求画质实际不可用（未解锁等），以接口返回的实际画质为准并在页面上如实显示

### 2. 切换清晰度时恢复播放进度

- 重推前通过 `GetPositionInfo` 记录设备当前播放进度，重推 `setUrl` + `play` 后 seek 回原进度
- 进度解析带完整容错：`NOT_IMPLEMENTED` / 片头 0 秒 / 响应缺 `RelTime` / 非法 XML 均跳过恢复，不影响正常切换
- 考虑到部分设备就绪需要时间，seek 在播放 0.5s 后发起，失败延时 1.5s 重试一次；恢复失败时设备从头播放，不影响其他功能

### 3. 投屏默认画质（设置）

- 新增设置项：**设置 -> 播放 -> 投屏默认画质**
- 默认「跟随播放画质」：投屏初始清晰度与播放页当前画质一致（保持现有行为，也避免电视端网络较差时默认高画质卡顿，见 #13 评论讨论）
- 也可固定指定为任意清晰度，仅影响初始投屏画质，投屏页内仍可随时切换

## 实现说明

- 新增 `DlnaArgs`：承载投屏上下文（cid / objectId / playurlType / url / qn / qualities），封装按清晰度取流逻辑，投屏页与播放页控制器共用
- `onCast` 改为通过 `Get.arguments` 传递完整投屏上下文（原先只传一次性 url 字符串，页面内无法重新取流）
- 新增 `parseSeekTime`（`dlna_utils.dart`）：从 `GetPositionInfo` SOAP 响应解析可恢复进度，纯函数
- 画质描述解析带降级链：接口描述 -> `VideoQuality` 枚举 desc -> code 字符串
- `VideoQuality` 新增 `tryFromCode` 可空查找，避免未知画质 code 导致崩溃

## 测试

- [x] `flutter analyze` 改动文件零问题
- [x] 清晰度解析 / 描述降级逻辑单元测试 8/8 通过
- [x] 进度恢复解析单元测试 7/7 通过（`NOT_IMPLEMENTED`、缺元素、非法 XML、毫秒进度等边界）
- [ ] 真机 + DLNA 设备实际投屏验证（建议合并前在真电视上验一轮：切换清晰度后重推与进度恢复是否正常，不同设备对 seek 时序的兼容性）
