### PR TITLE
fix(build): rename.py 全平台完整改名 + 包名统一为 org.frblanapps.pilisuper

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,10 +181,6 @@ jobs:
           flutter-version-file: pubspec.yaml
           cache: true
 
-      - name: Add Rename CLI tool
-        run: |
-            dart pub global activate rename
-
       - name: Rename project
         run: |
           NAME_ARGS=()
@@ -384,10 +380,6 @@ jobs:
           channel: stable
           flutter-version-file: pubspec.yaml
       
-      - name: Add Rename CLI tool
-        run: |
-            dart pub global activate rename
-
       - name: Rename project
         run: |
           NAME_ARGS=()
@@ -446,10 +438,6 @@ jobs:
 
       - name: Install create-dmg
         run: npm install --global create-dmg
-
-      - name: Add Rename CLI tool
-        run: |
-            dart pub global activate rename
 
       - name: Rename project
         run: |
@@ -524,10 +512,6 @@ jobs:
         run: |
           Copy-Item "windows/packaging/exe/ChineseSimplified.isl" `
             "C:\\Program Files (x86)\\Inno Setup 6\\Languages\\ChineseSimplified.isl"
-
-      - name: Add Rename CLI tool
-        run: |
-            dart pub global activate rename
 
       - name: Rename project
         shell: bash
@@ -636,10 +620,6 @@ jobs:
           channel: stable
           flutter-version-file: pubspec.yaml
           cache: true
-
-      - name: Add Rename CLI tool
-        run: |
-            dart pub global activate rename
 
       - name: Rename project
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,13 +182,16 @@ jobs:
           cache: true
 
       - name: Rename project
+        env:
+          APP_NAME: ${{ inputs.app_name }}
+          PKG_ID: ${{ inputs.pkg_id }}
         run: |
           NAME_ARGS=()
-          if [[ -n "${{ inputs.app_name}}" ]]; then
-            NAME_ARGS+=(--app-name "${{ inputs.app_name}}")
+          if [[ -n "$APP_NAME" ]]; then
+            NAME_ARGS+=(--app-name "$APP_NAME")
           fi
-          if [[ -n "${{ inputs.pkg_id }}" ]]; then
-            NAME_ARGS+=(--pkg-id "${{ inputs.pkg_id }}")
+          if [[ -n "$PKG_ID" ]]; then
+            NAME_ARGS+=(--pkg-id "$PKG_ID")
           fi
           python3 tool/build/rename.py "${NAME_ARGS[@]}"
 
@@ -266,13 +269,16 @@ jobs:
       - name: Build release APKs
         if: ${{ inputs.build_android_release == true }}
         env:
+          APP_NAME: ${{ inputs.app_name || 'PiliSuper' }}
+          SIGN_ANDROID: ${{ inputs.sign_android }}
+          EVENT_NAME: ${{ github.event_name }}
           KEYSTORE_B64: ${{ secrets.SIGN_KEYSTORE_BASE64 }}
           KEY_ALIAS:    ${{ secrets.KEY_ALIAS }}
           KEY_PASS:     ${{ secrets.KEY_PASSWORD }}
           STORE_PASS:   ${{ secrets.KEYSTORE_PASSWORD }}
         run: |
           SIGN_ARGS=()
-          if [[ "${{ inputs.sign_android }}" == "true" || ( "${{ github.event_name }}" == "workflow_dispatch" && -n "$KEYSTORE_B64" ) ]]; then
+          if [[ "$SIGN_ANDROID" == "true" || ( "$EVENT_NAME" == "workflow_dispatch" && -n "$KEYSTORE_B64" ) ]]; then
             if [[ -z "$KEYSTORE_B64" || -z "$KEY_ALIAS" || -z "$KEY_PASS" ]]; then
               echo "Android signing was requested but signing secrets are incomplete" >&2
               exit 1
@@ -285,10 +291,13 @@ jobs:
               --clean-keys
             )
           fi
-          python3 tool/build/build_android.py --version "$VERSION" --output-prefix "${{ inputs.app_name || 'PiliSuper' }}" --output dist "${SIGN_ARGS[@]}"
+          python3 tool/build/build_android.py --version "$VERSION" --output-prefix "$APP_NAME" --output dist "${SIGN_ARGS[@]}"
 
       - name: Build Dev
         env:
+          APP_NAME: ${{ inputs.app_name || 'PiliSuper' }}
+          SIGN_ANDROID: ${{ inputs.sign_android }}
+          EVENT_NAME: ${{ github.event_name }}
           KEYSTORE_B64: ${{ secrets.SIGN_KEYSTORE_BASE64 }}
           KEY_ALIAS:    ${{ secrets.KEY_ALIAS }}
           KEY_PASS:     ${{ secrets.KEY_PASSWORD }}
@@ -296,7 +305,7 @@ jobs:
         if: ${{ inputs.build_android_dev == true }}
         run: |
           SIGN_ARGS=()
-          if [[ "${{ inputs.sign_android }}" == "true" || ( "${{ github.event_name }}" == "workflow_dispatch" && -n "$KEYSTORE_B64" ) ]]; then
+          if [[ "$SIGN_ANDROID" == "true" || ( "$EVENT_NAME" == "workflow_dispatch" && -n "$KEYSTORE_B64" ) ]]; then
             if [[ -z "$KEYSTORE_B64" || -z "$KEY_ALIAS" || -z "$KEY_PASS" ]]; then
               echo "Android signing was requested but signing secrets are incomplete" >&2
               exit 1
@@ -311,7 +320,7 @@ jobs:
           fi
 
           VERSION=$(sed -n 's/^version: //p' pubspec.yaml)
-          python3 tool/build/build_android.py --version "$VERSION" --output-prefix "${{ inputs.app_name || 'PiliSuper' }}" --output dist --dev "${SIGN_ARGS[@]}"
+          python3 tool/build/build_android.py --version "$VERSION" --output-prefix "$APP_NAME" --output dist --dev "${SIGN_ARGS[@]}"
 
       - name: Release
         if: ${{ inputs.tag != '' }}
@@ -381,13 +390,16 @@ jobs:
           flutter-version-file: pubspec.yaml
       
       - name: Rename project
+        env:
+          APP_NAME: ${{ inputs.app_name }}
+          PKG_ID: ${{ inputs.pkg_id }}
         run: |
           NAME_ARGS=()
-          if [[ -n "${{ inputs.app_name}}" ]]; then
-            NAME_ARGS+=(--app-name "${{ inputs.app_name}}")
+          if [[ -n "$APP_NAME" ]]; then
+            NAME_ARGS+=(--app-name "$APP_NAME")
           fi
-          if [[ -n "${{ inputs.pkg_id }}" ]]; then
-            NAME_ARGS+=(--pkg-id "${{ inputs.pkg_id }}")
+          if [[ -n "$PKG_ID" ]]; then
+            NAME_ARGS+=(--pkg-id "$PKG_ID")
           fi
           python3 tool/build/rename.py "${NAME_ARGS[@]}"
 
@@ -403,7 +415,9 @@ jobs:
         run: flutter pub get
 
       - name: Build IPA
-        run: python3 tool/build/build_ios.py --version "$VERSION" --output-prefix "${{ inputs.app_name || 'PiliSuper' }}" --output dist
+        env:
+          APP_NAME: ${{ inputs.app_name || 'PiliSuper' }}
+        run: python3 tool/build/build_ios.py --version "$VERSION" --output-prefix "$APP_NAME" --output dist
 
       - name: Release
         if: ${{ inputs.tag != '' }}
@@ -440,13 +454,16 @@ jobs:
         run: npm install --global create-dmg
 
       - name: Rename project
+        env:
+          APP_NAME: ${{ inputs.app_name }}
+          PKG_ID: ${{ inputs.pkg_id }}
         run: |
           NAME_ARGS=()
-          if [[ -n "${{ inputs.app_name}}" ]]; then
-            NAME_ARGS+=(--app-name "${{ inputs.app_name}}")
+          if [[ -n "$APP_NAME" ]]; then
+            NAME_ARGS+=(--app-name "$APP_NAME")
           fi
-          if [[ -n "${{ inputs.pkg_id }}" ]]; then
-            NAME_ARGS+=(--pkg-id "${{ inputs.pkg_id }}")
+          if [[ -n "$PKG_ID" ]]; then
+            NAME_ARGS+=(--pkg-id "$PKG_ID")
           fi
           python3 tool/build/rename.py "${NAME_ARGS[@]}"
 
@@ -462,7 +479,9 @@ jobs:
         run: flutter pub get
 
       - name: Build macOS archive
-        run: python3 tool/build/build_macos.py --version "$VERSION" --output-prefix "${{ inputs.app_name || 'PiliSuper' }}" --output dist
+        env:
+          APP_NAME: ${{ inputs.app_name || 'PiliSuper' }}
+        run: python3 tool/build/build_macos.py --version "$VERSION" --output-prefix "$APP_NAME" --output dist
 
       - name: Release
         if: ${{ inputs.tag != '' }}
@@ -515,13 +534,16 @@ jobs:
 
       - name: Rename project
         shell: bash
+        env:
+          APP_NAME: ${{ inputs.app_name }}
+          PKG_ID: ${{ inputs.pkg_id }}
         run: |
           NAME_ARGS=()
-          if [[ -n "${{ inputs.app_name}}" ]]; then
-            NAME_ARGS+=(--app-name "${{ inputs.app_name}}")
+          if [[ -n "$APP_NAME" ]]; then
+            NAME_ARGS+=(--app-name "$APP_NAME")
           fi
-          if [[ -n "${{ inputs.pkg_id }}" ]]; then
-            NAME_ARGS+=(--pkg-id "${{ inputs.pkg_id }}")
+          if [[ -n "$PKG_ID" ]]; then
+            NAME_ARGS+=(--pkg-id "$PKG_ID")
           fi
           python tool/build/rename.py "${NAME_ARGS[@]}"
 
@@ -542,12 +564,16 @@ jobs:
       - name: Build portable Windows archive
         if: ${{ inputs.build_windows_portable == true }}
         shell: bash
-        run: python tool/build/build_windows.py --version "$VERSION" --output-prefix "${{ inputs.app_name || 'PiliSuper' }}" --output dist
+        env:
+          APP_NAME: ${{ inputs.app_name || 'PiliSuper' }}
+        run: python tool/build/build_windows.py --version "$VERSION" --output-prefix "$APP_NAME" --output dist
 
       - name: Build Windows installer
         if: ${{ inputs.build_windows_installer == true }}
         shell: bash
-        run: python tool/build/build_windows.py --installer --version "$VERSION" --output-prefix "${{ inputs.app_name || 'PiliSuper' }}" --output dist
+        env:
+          APP_NAME: ${{ inputs.app_name || 'PiliSuper' }}
+        run: python tool/build/build_windows.py --installer --version "$VERSION" --output-prefix "$APP_NAME" --output dist
 
       - name: Release
         if: ${{ inputs.tag != '' }}
@@ -622,13 +648,16 @@ jobs:
           cache: true
 
       - name: Rename project
+        env:
+          APP_NAME: ${{ inputs.app_name }}
+          PKG_ID: ${{ inputs.pkg_id }}
         run: |
           NAME_ARGS=()
-          if [[ -n "${{ inputs.app_name}}" ]]; then
-            NAME_ARGS+=(--app-name "${{ inputs.app_name}}")
+          if [[ -n "$APP_NAME" ]]; then
+            NAME_ARGS+=(--app-name "$APP_NAME")
           fi
-          if [[ -n "${{ inputs.pkg_id }}" ]]; then
-            NAME_ARGS+=(--pkg-id "${{ inputs.pkg_id }}")
+          if [[ -n "$PKG_ID" ]]; then
+            NAME_ARGS+=(--pkg-id "$PKG_ID")
           fi
           python3 tool/build/rename.py "${NAME_ARGS[@]}"
 
@@ -651,19 +680,31 @@ jobs:
 
       - name: Package Linux tar.gz
         if: ${{ inputs.build_linux_tar_gz == true || inputs.build_linux_arch == true }}
-        run: python3 tool/build/packaging.py --version "$VERSION" --output-prefix "${{ inputs.app_name || 'PiliSuper' }}" --app-name "${{ inputs.app_name || 'PiliSuper' }}" --pkg-id "${{ inputs.pkg_id || 'org.frblanapps.pilisuper' }}" --output dist tar.gz
+        env:
+          APP_NAME: ${{ inputs.app_name || 'PiliSuper' }}
+          PKG_ID: ${{ inputs.pkg_id || 'org.frblanapps.pilisuper' }}
+        run: python3 tool/build/packaging.py --version "$VERSION" --output-prefix "$APP_NAME" --app-name "$APP_NAME" --pkg-id "$PKG_ID" --output dist tar.gz
 
       - name: Package Linux DEB
         if: ${{ inputs.build_linux_deb == true }}
-        run: python3 tool/build/packaging.py --version "$VERSION" --output-prefix "${{ inputs.app_name || 'PiliSuper' }}" --app-name "${{ inputs.app_name || 'PiliSuper' }}" --pkg-id "${{ inputs.pkg_id || 'org.frblanapps.pilisuper' }}" --output dist deb
+        env:
+          APP_NAME: ${{ inputs.app_name || 'PiliSuper' }}
+          PKG_ID: ${{ inputs.pkg_id || 'org.frblanapps.pilisuper' }}
+        run: python3 tool/build/packaging.py --version "$VERSION" --output-prefix "$APP_NAME" --app-name "$APP_NAME" --pkg-id "$PKG_ID" --output dist deb
 
       - name: Package Linux RPM
         if: ${{ inputs.build_linux_rpm == true }}
-        run: python3 tool/build/packaging.py --version "$VERSION" --output-prefix "${{ inputs.app_name || 'PiliSuper' }}" --app-name "${{ inputs.app_name || 'PiliSuper' }}" --pkg-id "${{ inputs.pkg_id || 'org.frblanapps.pilisuper' }}" --output dist rpm
+        env:
+          APP_NAME: ${{ inputs.app_name || 'PiliSuper' }}
+          PKG_ID: ${{ inputs.pkg_id || 'org.frblanapps.pilisuper' }}
+        run: python3 tool/build/packaging.py --version "$VERSION" --output-prefix "$APP_NAME" --app-name "$APP_NAME" --pkg-id "$PKG_ID" --output dist rpm
 
       - name: Package Linux AppImage
         if: ${{ inputs.build_linux_appimage == true }}
-        run: python3 tool/build/packaging.py --version "$VERSION" --output-prefix "${{ inputs.app_name || 'PiliSuper' }}" --app-name "${{ inputs.app_name || 'PiliSuper' }}" --pkg-id "${{ inputs.pkg_id || 'org.frblanapps.pilisuper' }}" --output dist appimage
+        env:
+          APP_NAME: ${{ inputs.app_name || 'PiliSuper' }}
+          PKG_ID: ${{ inputs.pkg_id || 'org.frblanapps.pilisuper' }}
+        run: python3 tool/build/packaging.py --version "$VERSION" --output-prefix "$APP_NAME" --app-name "$APP_NAME" --pkg-id "$PKG_ID" --output dist appimage
 
       - name: Upload Linux bundle for Arch packaging
         if: ${{ inputs.build_linux_arch == true }}
@@ -730,9 +771,11 @@ jobs:
           path: arch-input
 
       - name: Extract Linux bundle
+        env:
+          APP_NAME: ${{ inputs.app_name || 'PiliSuper' }}
         run: |
           mkdir -p build/linux/x64/release/bundle
-          tar -xzf arch-input/${{ inputs.app_name || 'PiliSuper' }}_linux_*.tar.gz \
+          tar -xzf "arch-input/${APP_NAME}"_linux_*.tar.gz \
             -C build/linux/x64/release/bundle
 
       - name: Create unprivileged package user
@@ -741,12 +784,15 @@ jobs:
           chown -R builder:builder "$GITHUB_WORKSPACE"
 
       - name: Build Arch package
+        env:
+          APP_NAME: ${{ inputs.app_name || 'PiliSuper' }}
+          PKG_ID: ${{ inputs.pkg_id || 'org.frblanapps.pilisuper' }}
         run: |
           runuser -u builder -- python3 tool/build/packaging.py \
             --version "${{ needs.linux.outputs.version }}" \
-            --output-prefix "${{ inputs.app_name || 'PiliSuper' }}" \
-            --app-name "${{ inputs.app_name || 'PiliSuper' }}" \
-            --pkg-id "${{ inputs.pkg_id || 'org.frblanapps.pilisuper' }}" \
+            --output-prefix "$APP_NAME" \
+            --app-name "$APP_NAME" \
+            --pkg-id "$PKG_ID" \
             --output dist \
             arch
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ on:
       pkg_id:
         required: false
         type: string
-        default: "com.pili.super"
+        default: "org.frblanapps.pilisuper"
       app_name:
         required: false
         type: string
@@ -99,7 +99,7 @@ on:
       pkg_id:
         description: "包名（留空则使用默认值）"
         required: false
-        default: "com.pili.super"
+        default: "org.frblanapps.pilisuper"
         type: string
       app_name:
         description: "应用名（留空则使用默认值）"
@@ -671,19 +671,19 @@ jobs:
 
       - name: Package Linux tar.gz
         if: ${{ inputs.build_linux_tar_gz == true || inputs.build_linux_arch == true }}
-        run: python3 tool/build/packaging.py --version "$VERSION" --output-prefix "${{ inputs.app_name || 'PiliSuper' }}" --app-name "${{ inputs.app_name || 'PiliSuper' }}" --pkg-id "${{ inputs.pkg_id || 'com.pili.super' }}" --output dist tar.gz
+        run: python3 tool/build/packaging.py --version "$VERSION" --output-prefix "${{ inputs.app_name || 'PiliSuper' }}" --app-name "${{ inputs.app_name || 'PiliSuper' }}" --pkg-id "${{ inputs.pkg_id || 'org.frblanapps.pilisuper' }}" --output dist tar.gz
 
       - name: Package Linux DEB
         if: ${{ inputs.build_linux_deb == true }}
-        run: python3 tool/build/packaging.py --version "$VERSION" --output-prefix "${{ inputs.app_name || 'PiliSuper' }}" --app-name "${{ inputs.app_name || 'PiliSuper' }}" --pkg-id "${{ inputs.pkg_id || 'com.pili.super' }}" --output dist deb
+        run: python3 tool/build/packaging.py --version "$VERSION" --output-prefix "${{ inputs.app_name || 'PiliSuper' }}" --app-name "${{ inputs.app_name || 'PiliSuper' }}" --pkg-id "${{ inputs.pkg_id || 'org.frblanapps.pilisuper' }}" --output dist deb
 
       - name: Package Linux RPM
         if: ${{ inputs.build_linux_rpm == true }}
-        run: python3 tool/build/packaging.py --version "$VERSION" --output-prefix "${{ inputs.app_name || 'PiliSuper' }}" --app-name "${{ inputs.app_name || 'PiliSuper' }}" --pkg-id "${{ inputs.pkg_id || 'com.pili.super' }}" --output dist rpm
+        run: python3 tool/build/packaging.py --version "$VERSION" --output-prefix "${{ inputs.app_name || 'PiliSuper' }}" --app-name "${{ inputs.app_name || 'PiliSuper' }}" --pkg-id "${{ inputs.pkg_id || 'org.frblanapps.pilisuper' }}" --output dist rpm
 
       - name: Package Linux AppImage
         if: ${{ inputs.build_linux_appimage == true }}
-        run: python3 tool/build/packaging.py --version "$VERSION" --output-prefix "${{ inputs.app_name || 'PiliSuper' }}" --app-name "${{ inputs.app_name || 'PiliSuper' }}" --pkg-id "${{ inputs.pkg_id || 'com.pili.super' }}" --output dist appimage
+        run: python3 tool/build/packaging.py --version "$VERSION" --output-prefix "${{ inputs.app_name || 'PiliSuper' }}" --app-name "${{ inputs.app_name || 'PiliSuper' }}" --pkg-id "${{ inputs.pkg_id || 'org.frblanapps.pilisuper' }}" --output dist appimage
 
       - name: Upload Linux bundle for Arch packaging
         if: ${{ inputs.build_linux_arch == true }}
@@ -766,7 +766,7 @@ jobs:
             --version "${{ needs.linux.outputs.version }}" \
             --output-prefix "${{ inputs.app_name || 'PiliSuper' }}" \
             --app-name "${{ inputs.app_name || 'PiliSuper' }}" \
-            --pkg-id "${{ inputs.pkg_id || 'com.pili.super' }}" \
+            --pkg-id "${{ inputs.pkg_id || 'org.frblanapps.pilisuper' }}" \
             --output dist \
             arch
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ flutter pub get
 例如，构建 Android release：
 
 ```sh
-python tool/build/rename.py --pkg-id com.pili.super --app-name PiliSuper
+python tool/build/rename.py --pkg-id org.frblanapps.pilisuper --app-name PiliSuper
 python tool/build/prebuild.py --platform android
 flutter pub get
 VERSION=$(sed -n 's/^version: //p' pubspec.yaml)

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ flutter pub get
 
 | 脚本 | 职责 |
 | --- | --- |
-| `tool/build/rename.py` | 改 Bundle ID、显示名、Dart 包名和仓库引用 |
+| `tool/build/rename.py` | 改 Bundle ID、显示名、Dart 包名、仓库引用和发行者署名 |
 | `tool/build/prebuild.py` | 生成 `pili_release.json` 并写入 Git 版本号 |
 | `tool/build/patch.py` | 为指定平台应用 Flutter SDK 或项目源码补丁 |
 | `tool/build/build_android.py` | 构建并导出 Android APK |

--- a/tool/build/packaging.py
+++ b/tool/build/packaging.py
@@ -15,7 +15,8 @@ from urllib.request import urlopen
 from build_common import log_success, require_command, run_command
 
 PACKAGE_NAME = "pilisuper"
-DESKTOP_FILE_NAME = "com.pili.super.desktop"
+DESKTOP_FILE_NAME = "org.frblanapps.pilisuper.desktop"
+LEGACY_DESKTOP_FILE_NAME = "com.pili.super.desktop"
 ICON_NAME = "pilisuper"
 
 
@@ -27,8 +28,10 @@ class PackageIdentity:
 
 
 def package_identity(pkg_id: str) -> PackageIdentity:
-    if pkg_id == "com.pili.super":
+    if pkg_id == "org.frblanapps.pilisuper":
         return PackageIdentity(PACKAGE_NAME, DESKTOP_FILE_NAME, ICON_NAME)
+    if pkg_id == "com.pili.super":
+        return PackageIdentity(PACKAGE_NAME, LEGACY_DESKTOP_FILE_NAME, ICON_NAME)
     normalized = re.sub(r"[^a-z0-9.+-]", "-", pkg_id.lower())
     return PackageIdentity(normalized, f"{normalized}.desktop", normalized)
 
@@ -317,7 +320,7 @@ def main() -> None:
     parser.add_argument("--output", default="dist")
     parser.add_argument("--output-prefix", default="PiliSuper")
     parser.add_argument("--app-name", default="PiliSuper")
-    parser.add_argument("--pkg-id", default="com.pili.super")
+    parser.add_argument("--pkg-id", default="org.frblanapps.pilisuper")
     parser.add_argument("targets", nargs="+", choices=["tar.gz", "zst", "deb", "rpm", "arch", "appimage"])
     args = parser.parse_args()
 

--- a/tool/build/rename.py
+++ b/tool/build/rename.py
@@ -1,34 +1,307 @@
 #!/usr/bin/env python3
-"""Rename the Flutter project identity (package, display name, and repository)."""
+"""Rename the Flutter project identity (package, display name, and repository).
+
+The tree intentionally keeps upstream identifiers to ease merges; this script
+is the build-time step that rewrites the whole tree to the fork identity:
+Dart package, bundle id (dotted/slash + source dirs + file names), display
+name, binary name, and repository references. Upstream attribution (license
+headers, credits, git dependency URLs) is preserved.
+
+全平台统一使用 --pkg-id（org.frblanapps.pilisuper），它同时也是 Android 的
+namespace 与 Java/Kotlin 源码包，因此必须是合法的 Java 包名（不含保留字；
+例如 com.pili.super 中的 super 会导致编译失败）。
+"""
 from __future__ import annotations
 
 import argparse
+import os
 import re
+import shutil
 from pathlib import Path
+from typing import Callable
 
-from build_common import (log_info, log_step, log_success, log_warning,
-                          require_command, require_project_root, run_command)
+from build_common import (log_error, log_info, log_step, log_success,
+                          log_warning, require_project_root)
 
-SKIP_DIRECTORIES = {".git", ".dart_tool", "build", "Pods", "ephemeral"}
+SKIP_DIRECTORIES = {".git", ".codegraph", ".dart_tool", ".omo", ".pytest_cache",
+                    ".fvm", ".idea", "build", "dist", "node_modules", "Pods",
+                    "ephemeral"}
+
+# 仓库引用替换时整行跳过的上游署名标记（README 致谢、issue 模板的“上游 issue”链接）。
+ATTRIBUTION_LINE = re.compile(r"致敬|原作者|上上游|上游|[Uu]pstream|[Aa]cknowledg")
+# README 同时包含自仓引用与上游致谢，人工维护，不参与自动替换。
+MANUAL_FILES = {"README.md"}
+
+# Java/Kotlin 保留字：包名（同时是 Android namespace）段不允许出现。
+RESERVED_WORDS = {
+    "abstract", "assert", "boolean", "break", "byte", "case", "catch", "char",
+    "class", "const", "continue", "default", "do", "double", "else", "enum",
+    "extends", "final", "finally", "float", "for", "fun", "goto", "if",
+    "implements", "import", "in", "infix", "init", "inline", "instanceof",
+    "int", "interface", "is", "long", "native", "new", "object", "open",
+    "operator", "out", "override", "package", "private", "protected", "public",
+    "return", "sealed", "short", "static", "strictfp", "super", "switch",
+    "synchronized", "this", "throw", "throws", "transient", "try", "typealias",
+    "val", "var", "vararg", "void", "volatile", "when", "where", "while",
+}
+
+SELF_PATH = Path(__file__).resolve()
 
 
-def replace_in_files(old: str, new: str, patterns: list[str]) -> None:
-    for pattern in patterns:
-        for path in Path(".").glob(pattern):
-            if not path.is_file() or any(part in SKIP_DIRECTORIES for part in path.parts):
+def validate_package(pkg_id: str) -> None:
+    for segment in pkg_id.split("."):
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", segment) or segment in RESERVED_WORDS:
+            log_error(f"{pkg_id} 不是合法的 Java/Kotlin 包名（含保留字或非法段），将导致 Android 构建失败。")
+            raise SystemExit(1)
+
+
+def iter_project_files() -> list[Path]:
+    files: list[Path] = []
+    for root, directories, names in os.walk("."):
+        directories[:] = sorted(d for d in directories if d not in SKIP_DIRECTORIES)
+        for name in names:
+            path = Path(root) / name
+            if path.resolve() == SELF_PATH:
                 continue
-            try:
-                content = path.read_text(encoding="utf-8")
-                if old in content:
-                    path.write_text(content.replace(old, new), encoding="utf-8")
-                    log_info(f"updated: {path}")
-            except UnicodeDecodeError:
-                continue
+            files.append(path)
+    return files
+
+
+def read_text(path: Path) -> str | None:
+    try:
+        with path.open(encoding="utf-8", newline="") as handle:
+            return handle.read()
+    except (UnicodeDecodeError, OSError):
+        return None
+
+
+def write_text(path: Path, content: str) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        handle.write(content)
+
+
+def transform_files(transform: Callable[[str], str], files: list[Path]) -> None:
+    for path in files:
+        content = read_text(path)
+        if content is None:
+            continue
+        updated = transform(content)
+        if updated != content:
+            write_text(path, updated)
+            log_info(f"updated: {path}")
+
+
+def protected_spans(
+    text: str, original_pkg_id: str, original_repo: str
+) -> list[tuple[int, int]]:
+    """Spans of old identifiers (bundle id, slash form, repo path) that
+    display-name/binary-name replacement must never touch — otherwise
+    bggRGjQaUbCoE/PiliPlus would be corrupted into bggRGjQaUbCoE/PiliSuper."""
+    identities = [original_pkg_id, original_pkg_id.replace(".", "/")]
+    if original_repo:
+        identities.append(original_repo)
+    pattern = "|".join(re.escape(identity) for identity in identities if identity)
+    if not pattern:
+        return []
+    return [match.span() for match in re.finditer(pattern, text, re.IGNORECASE)]
+
+
+def replace_word(text: str, old: str, new: str, protected: list[tuple[int, int]]) -> str:
+    """Whole-word replace that never touches bundle-id spans (com.example.PiliPlus)."""
+
+    def substitute(match: re.Match) -> str:
+        start, end = match.span()
+        if any(start < span_end and span_start < end for span_start, span_end in protected):
+            return match.group(0)
+        return new
+
+    return re.sub(rf"\b{re.escape(old)}\b", substitute, text)
+
+
+def rename_dart_package(app_name: str, original_app_name: str, files: list[Path]) -> None:
+    old_import = f"package:{original_app_name}/"
+    new_import = f"package:{app_name}/"
+    transform_files(lambda text: text.replace(old_import, new_import), files)
+    pubspec = Path("pubspec.yaml")
+    content = read_text(pubspec)
+    if content is None:
+        return
+    updated = re.sub(
+        rf"^(name:\s*){re.escape(original_app_name)}\b",
+        rf"\g<1>{app_name}",
+        content,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    if updated != content:
+        write_text(pubspec, updated)
+        log_info("updated: pubspec.yaml")
+
+
+def rename_bundle_id(pkg_id: str, original_pkg_id: str, files: list[Path]) -> None:
+    old_slash = original_pkg_id.replace(".", "/")
+    new_slash = pkg_id.replace(".", "/")
+    pattern = re.compile(
+        "|".join(re.escape(form) for form in {original_pkg_id, old_slash}),
+        re.IGNORECASE,
+    )
+
+    def substitute(match: re.Match) -> str:
+        return new_slash if "/" in match.group(0) else pkg_id
+
+    transform_files(lambda text: pattern.sub(substitute, text), files)
+
+
+def _display_label_file(path: Path) -> bool:
+    parts = path.parts
+    name = path.name
+    if name == "AndroidManifest.xml" and "android" in parts:
+        return True
+    if name == "string.xml" and "res" in parts and any(part.startswith("values") for part in parts):
+        return True
+    if "gradle" in name and parts[0] == "android":
+        return True
+    if name.endswith(".plist") and parts[0] in {"ios", "macos"}:
+        return True
+    if name == "AppInfo.xcconfig":
+        return True
+    if name == "make_config.yaml" and parts[:3] == ("windows", "packaging", "exe"):
+        return True
+    if parts[:2] == ("assets", "linux"):
+        return True
+    return parts[0] == ".vscode" and name.endswith(".json")
+
+
+def rename_display_name(
+    app_name: str,
+    original_app_name: str,
+    original_pkg_id: str,
+    original_repo: str,
+    files: list[Path],
+) -> None:
+    def word_transform(text: str) -> str:
+        return replace_word(
+            text,
+            original_app_name,
+            app_name,
+            protected_spans(text, original_pkg_id, original_repo),
+        )
+
+    transform_files(word_transform, [path for path in files if _display_label_file(path)])
+
+    # lib/test 内的显示名只出现在字符串字面量里（constants.dart 的 appName）；
+    # GPL 头、注释里的 PiliPlus 是上游内容，保持不动。
+    quoted = re.compile(rf"(['\"]){re.escape(original_app_name)}\1")
+
+    def quoted_transform(text: str) -> str:
+        protected = protected_spans(text, original_pkg_id, original_repo)
+
+        def substitute(match: re.Match) -> str:
+            start, end = match.span()
+            if any(start < span_end and span_start < end for span_start, span_end in protected):
+                return match.group(0)
+            return f"{match.group(1)}{app_name}{match.group(1)}"
+
+        return quoted.sub(substitute, text)
+
+    transform_files(quoted_transform, [p for p in files if p.parts[0] in {"lib", "test"}])
+
+
+def normalize_binary_name(name: str) -> str:
+    return re.sub(r"[^a-z0-9.+-]", "-", name.lower())
+
+
+def rename_binary_name(
+    app_name: str,
+    original_app_name: str,
+    original_pkg_id: str,
+    original_repo: str,
+    files: list[Path],
+) -> None:
+    old_binary = normalize_binary_name(original_app_name)
+    new_binary = normalize_binary_name(app_name)
+    if old_binary == new_binary:
+        return
+
+    def word_transform(text: str) -> str:
+        return replace_word(
+            text,
+            old_binary,
+            new_binary,
+            protected_spans(text, original_pkg_id, original_repo),
+        )
+
+    transform_files(
+        word_transform,
+        [p for p in files if p.parts[0] in {"linux", "windows", "macos", "assets"}],
+    )
+
+    # lib/test 内以旧二进制名开头的字符串字面量（备份/导出文件名前缀）。
+    prefix = re.compile(rf"(['\"]){re.escape(old_binary)}")
+
+    transform_files(
+        lambda text: prefix.sub(rf"\g<1>{new_binary}", text),
+        [p for p in files if p.parts[0] in {"lib", "test"}],
+    )
+
+
+def rename_repository(repo: str, original_repo: str, files: list[Path]) -> None:
+    def transform(text: str) -> str:
+        if original_repo not in text:
+            return text
+        updated = []
+        for line in text.splitlines(keepends=True):
+            if original_repo in line and not ATTRIBUTION_LINE.search(line):
+                line = line.replace(original_repo, repo)
+            updated.append(line)
+        return "".join(updated)
+
+    transform_files(transform, [p for p in files if p.name not in MANUAL_FILES])
+
+
+def _prune_empty_directories(directory: Path) -> None:
+    current = directory
+    while current != Path(".") and current.is_dir() and not any(current.iterdir()):
+        current.rmdir()
+        current = current.parent
+
+
+def move_package_directories(old_slash: str, new_slash: str) -> None:
+    sources: list[Path] = []
+    for root, directories, _names in os.walk("."):
+        directories[:] = sorted(d for d in directories if d not in SKIP_DIRECTORIES)
+        posix = Path(root).as_posix()
+        if posix != "." and (posix == old_slash or posix.endswith("/" + old_slash)):
+            sources.append(Path(root))
+            directories[:] = []
+    for source in sources:
+        relative = source.as_posix()
+        target = Path(relative[: relative.rfind(old_slash)] + new_slash)
+        if target.exists():
+            log_warning(f"跳过目录移动，目标已存在: {target}")
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(source), str(target))
+        _prune_empty_directories(source.parent)
+        log_info(f"moved: {source} -> {target}")
+
+
+def rename_identity_files(pkg_id: str, original_pkg_id: str) -> None:
+    pattern = re.compile(re.escape(original_pkg_id), re.IGNORECASE)
+    for path in iter_project_files():
+        if not pattern.search(path.name):
+            continue
+        target = path.with_name(pattern.sub(pkg_id, path.name))
+        if target.exists():
+            log_warning(f"跳过文件重命名，目标已存在: {target}")
+            continue
+        path.rename(target)
+        log_info(f"renamed: {path} -> {target}")
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--pkg-id", default="com.pili.super")
+    parser.add_argument("--pkg-id", default="org.frblanapps.pilisuper")
     parser.add_argument("--original-pkg-id", default="com.example.piliplus")
     parser.add_argument("--app-name", default="PiliSuper")
     parser.add_argument("--original-app-name", default="PiliPlus")
@@ -37,23 +310,36 @@ def main() -> None:
     args = parser.parse_args()
 
     require_project_root()
+    validate_package(args.pkg_id)
+    files = iter_project_files()
+
     if args.app_name != args.original_app_name:
         log_step("Rename Dart package")
-        replace_in_files(f"package:{args.original_app_name}/", f"package:{args.app_name}/", ["**/*.dart", "**/*.patch"])
-        pubspec = Path("pubspec.yaml")
-        pubspec.write_text(re.sub(r"^(name:\s+)" + re.escape(args.original_app_name), r"\g<1>" + args.app_name, pubspec.read_text(encoding="utf-8"), flags=re.MULTILINE), encoding="utf-8")
+        rename_dart_package(args.app_name, args.original_app_name, files)
+        log_step("Rename display name")
+        rename_display_name(
+            args.app_name, args.original_app_name, args.original_pkg_id, args.original_repo, files
+        )
+        log_step("Rename binary name")
+        rename_binary_name(
+            args.app_name, args.original_app_name, args.original_pkg_id, args.original_repo, files
+        )
 
     if args.pkg_id != args.original_pkg_id:
-        log_step("Rename native package path")
-        replace_in_files(args.original_pkg_id.replace(".", "/"), args.pkg_id.replace(".", "/"), ["android/**/*", "ios/**/*", "macos/**/*", "linux/**/*", "windows/**/*"])
+        log_step("Rename bundle identifier")
+        rename_bundle_id(args.pkg_id, args.original_pkg_id, files)
 
     if args.repo != args.original_repo:
         log_step("Rename repository references")
-        replace_in_files(args.original_repo, args.repo, ["assets/linux/**/*", "lib/**/*.dart", "windows/packaging/exe/make_config.yaml"])
+        rename_repository(args.repo, args.original_repo, files)
 
-    require_command("rename", "请先运行：dart pub global activate rename")
-    run_command(["rename", "setBundleId", "--value", args.pkg_id])
-    run_command(["rename", "setAppName", "--value", args.app_name])
+    if args.pkg_id != args.original_pkg_id:
+        # 结构性变更放在最后：前面的内容替换都基于原始路径进行。
+        move_package_directories(
+            args.original_pkg_id.replace(".", "/"), args.pkg_id.replace(".", "/")
+        )
+        rename_identity_files(args.pkg_id, args.original_pkg_id)
+
     log_success("项目标识已更新")
 
 

--- a/tool/build/rename.py
+++ b/tool/build/rename.py
@@ -39,7 +39,7 @@ import shutil
 from pathlib import Path
 
 from build_common import (log_error, log_info, log_step, log_success,
-                          log_warning, require_project_root)
+                          require_project_root)
 
 SELF_PATH = Path(__file__).resolve()
 
@@ -145,6 +145,26 @@ def project_files():
     return found
 
 
+def require_no_symlinks(files):
+    """Reject links before any rewrite can follow them outside the tree."""
+    for directory, subdirectories, names in os.walk("."):
+        for name in (*subdirectories, *names):
+            path = Path(directory) / name
+            if path.is_symlink():
+                log_error(f"拒绝处理符号链接: {path}")
+                raise SystemExit(1)
+
+    for path in files:
+        if path.is_symlink():
+            log_error(f"拒绝处理符号链接: {path}")
+            raise SystemExit(1)
+
+    pubspec = Path("pubspec.yaml")
+    if pubspec.is_symlink():
+        log_error(f"拒绝处理符号链接: {pubspec}")
+        raise SystemExit(1)
+
+
 def read_text(path):
     """Contents with line endings kept verbatim, or None if the file is not text."""
     try:
@@ -155,6 +175,9 @@ def read_text(path):
 
 
 def write_text(path, content):
+    if path.is_symlink():
+        log_error(f"拒绝写入符号链接: {path}")
+        raise SystemExit(1)
     with path.open("w", encoding="utf-8", newline="") as handle:
         handle.write(content)
 
@@ -395,7 +418,7 @@ def remove_empty_parents(leaf):
         directory = directory.parent
 
 
-def move_source_directories(old_pkg_id, new_pkg_id):
+def source_directory_operations(old_pkg_id, new_pkg_id):
     """Relocate `.../com/example/piliplus/` source folders to the new package."""
     old_pkg_path = old_pkg_id.replace(".", "/")
     new_pkg_path = new_pkg_id.replace(".", "/")
@@ -408,28 +431,64 @@ def move_source_directories(old_pkg_id, new_pkg_id):
             sources.append(Path(directory))
             subdirectories[:] = []  # the package folder is the leaf we move
 
-    for source in sources:
-        location = source.as_posix()
-        target = Path(location[: location.rfind(old_pkg_path)] + new_pkg_path)
-        if target.exists():
-            log_warning(f"跳过目录移动，目标已存在: {target}")
-            continue
+    return [
+        (
+            source,
+            Path(source.as_posix()[: source.as_posix().rfind(old_pkg_path)] + new_pkg_path),
+        )
+        for source in sources
+    ]
+
+
+def identity_file_operations(old_pkg_id, new_pkg_id, files=None):
+    old_id = re.compile(re.escape(old_pkg_id), re.IGNORECASE)
+    operations = []
+    for path in files if files is not None else project_files():
+        if old_id.search(path.name):
+            operations.append((path, path.with_name(old_id.sub(new_pkg_id, path.name))))
+    return operations
+
+
+def require_structural_destinations_available(operations):
+    destinations = set()
+    for source, target in operations:
+        resolved_target = target.absolute()
+        if resolved_target in destinations:
+            log_error(f"结构目标重复: {source} -> {target}")
+            raise SystemExit(1)
+        destinations.add(resolved_target)
+        if os.path.lexists(target):
+            log_error(f"结构目标已存在: {source} -> {target}")
+            raise SystemExit(1)
+
+
+def move_source_directories(old_pkg_id, new_pkg_id, operations=None):
+    operations = (
+        source_directory_operations(old_pkg_id, new_pkg_id)
+        if operations is None
+        else operations
+    )
+    for source, target in operations:
+        if os.path.lexists(target):
+            log_error(f"结构目标已存在: {source} -> {target}")
+            raise SystemExit(1)
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.move(str(source), str(target))
         remove_empty_parents(source.parent)
         log_info(f"moved: {source} -> {target}")
 
 
-def rename_identity_files(old_pkg_id, new_pkg_id):
+def rename_identity_files(old_pkg_id, new_pkg_id, operations=None):
     """Files named after the bundle id, such as `com.example.piliplus.desktop`."""
-    old_id = re.compile(re.escape(old_pkg_id), re.IGNORECASE)
-    for path in project_files():
-        if not old_id.search(path.name):
-            continue
-        target = path.with_name(old_id.sub(new_pkg_id, path.name))
-        if target.exists():
-            log_warning(f"跳过文件重命名，目标已存在: {target}")
-            continue
+    operations = (
+        identity_file_operations(old_pkg_id, new_pkg_id)
+        if operations is None
+        else operations
+    )
+    for path, target in operations:
+        if os.path.lexists(target):
+            log_error(f"结构目标已存在: {path} -> {target}")
+            raise SystemExit(1)
         path.rename(target)
         log_info(f"renamed: {path} -> {target}")
 
@@ -462,6 +521,14 @@ def main():
     # Listed once, before anything moves: the content passes below all work on
     # pre-rename paths, and the structural passes walk the tree again themselves.
     files = project_files()
+    require_no_symlinks(files)
+
+    directory_operations = []
+    identity_operations = []
+    if new_pkg_id != old_pkg_id:
+        directory_operations = source_directory_operations(old_pkg_id, new_pkg_id)
+        identity_operations = identity_file_operations(old_pkg_id, new_pkg_id, files)
+        require_structural_destinations_available(directory_operations + identity_operations)
 
     if new_app_name != old_app_name:
         log_step("Rename Dart package")
@@ -485,8 +552,8 @@ def main():
 
     if new_pkg_id != old_pkg_id:
         # Structural changes come last, so every pass above saw the old paths.
-        move_source_directories(old_pkg_id, new_pkg_id)
-        rename_identity_files(old_pkg_id, new_pkg_id)
+        move_source_directories(old_pkg_id, new_pkg_id, directory_operations)
+        rename_identity_files(old_pkg_id, new_pkg_id, identity_operations)
 
     log_success("项目标识已更新")
 

--- a/tool/build/rename.py
+++ b/tool/build/rename.py
@@ -3,13 +3,14 @@
 
 The working tree deliberately keeps the upstream identifiers so that merges
 from upstream stay conflict-free. This script is the build step that swaps
-them for the fork identity across every platform, in five passes:
+them for the fork identity across every platform, in six passes:
 
     dart package   package:PiliPlus/...     ->  package:PiliSuper/...
     display name   "PiliPlus" labels        ->  "PiliSuper"
     binary name    piliplus executables     ->  pilisuper
     bundle id      com.example.piliplus     ->  org.frblanapps.pilisuper
     repository     bggRGjQaUbCoE/PiliPlus   ->  FRBLanApps/PiliSuper
+    publisher      com.example copyright    ->  FRBLanApps
 
 Upstream attribution survives on purpose: license headers, credit lines and
 git dependency URLs keep naming PiliPlus and bggRGjQaUbCoE.
@@ -54,6 +55,26 @@ RESERVED_WORDS = {
     "synchronized", "this", "throw", "throws", "transient", "try", "typealias",
     "val", "var", "vararg", "void", "volatile", "when", "where", "while",
 }
+
+# Runner fields that hold a user-visible label which `flutter create` seeded
+# from the lowercase project name instead of the display name. Pass 2 matches
+# the display name case-sensitively and so walks past `piliplus`, after which
+# pass 3 would demote these labels to the executable name.
+DISPLAY_NAME_FIELDS = (
+    re.compile(r'VALUE\s+"(?:FileDescription|ProductName)"'),
+    re.compile(r'::FindWindow\(|window\.Create\(L"'),
+    re.compile(r"gtk_(?:window|header_bar)_set_title\("),
+)
+
+# Runner fields that name the vendor rather than the app; upstream leaves the
+# `flutter create` sample value there.
+PUBLISHER_FIELDS = (
+    re.compile(r'VALUE\s+"(?:CompanyName|LegalCopyright)"'),
+    re.compile(r"^\s*PRODUCT_COPYRIGHT\s*="),
+)
+
+# Platform runners carry both kinds of field.
+RUNNER_TREES = {"windows", "linux", "macos"}
 
 
 # ---------------------------------------------------------------------------
@@ -105,6 +126,24 @@ def rewrite(files, rewriter):
         if after != before:
             write_text(path, after)
             log_info(f"updated: {path}")
+
+
+def on_field_lines(fields, substitute):
+    """A rewriter that runs `substitute` only on lines holding one of `fields`.
+
+    Keeps the edit off neighbouring lines, so `InternalName` and
+    `OriginalFilename` keep the executable name while the label fields beside
+    them take the display name.
+    """
+    def rewriter(text):
+        lines = []
+        for line in text.splitlines(keepends=True):
+            if any(field.search(line) for field in fields):
+                line = substitute(line)
+            lines.append(line)
+        return "".join(lines)
+
+    return rewriter
 
 
 def spans_to_keep(text, *phrases):
@@ -184,6 +223,7 @@ def rename_display_name(old_app_name, new_app_name, old_pkg_id, old_repo, files)
     old_pkg_path = old_pkg_id.replace(".", "/")
     word = re.compile(rf"\b{re.escape(old_app_name)}\b")
     quoted = re.compile(rf"(['\"]){re.escape(old_app_name)}\1")
+    any_case = re.compile(rf"\b{re.escape(old_app_name)}\b", re.IGNORECASE)
 
     def replace_words(text):
         kept = spans_to_keep(text, old_pkg_id, old_pkg_path, old_repo)
@@ -196,8 +236,18 @@ def rename_display_name(old_app_name, new_app_name, old_pkg_id, old_repo, files)
             text,
         )
 
+    def replace_any_case(line):
+        kept = spans_to_keep(line, old_pkg_id, old_pkg_path, old_repo)
+        return any_case.sub(
+            lambda m: m[0] if overlaps(m.span(), kept) else new_app_name, line
+        )
+
     rewrite([p for p in files if declares_display_label(p)], replace_words)
     rewrite([p for p in files if p.parts[0] in {"lib", "test"}], replace_string_literals)
+    rewrite(
+        [p for p in files if p.parts[0] in RUNNER_TREES],
+        on_field_lines(DISPLAY_NAME_FIELDS, replace_any_case),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -275,6 +325,22 @@ def rename_repository(old_repo, new_repo, files):
 
 
 # ---------------------------------------------------------------------------
+# Pass 6 —— 发行者：runner 里 flutter create 留下的 com.example 署名
+# ---------------------------------------------------------------------------
+
+def rename_publisher(old_publisher, new_publisher, files):
+    """`CompanyName`, `LegalCopyright` and `PRODUCT_COPYRIGHT` still credit the
+    `flutter create` sample vendor. Pass 4 walks past them because they carry
+    the vendor prefix alone, not the whole bundle id."""
+    vendor = re.compile(rf"{re.escape(old_publisher)}(?!\.\w)")
+
+    rewrite(
+        [p for p in files if p.parts[0] in RUNNER_TREES],
+        on_field_lines(PUBLISHER_FIELDS, lambda line: vendor.sub(new_publisher, line)),
+    )
+
+
+# ---------------------------------------------------------------------------
 # 结构性变更：移动源码目录、重命名以 bundle id 命名的文件
 # ---------------------------------------------------------------------------
 
@@ -337,11 +403,14 @@ def main():
     parser.add_argument("--original-app-name", default="PiliPlus")
     parser.add_argument("--repo", default="FRBLanApps/PiliSuper")
     parser.add_argument("--original-repo", default="bggRGjQaUbCoE/PiliPlus")
+    parser.add_argument("--publisher", default="FRBLanApps")
+    parser.add_argument("--original-publisher", default="com.example")
     args = parser.parse_args()
 
     old_app_name, new_app_name = args.original_app_name, args.app_name
     old_pkg_id, new_pkg_id = args.original_pkg_id, args.pkg_id
     old_repo, new_repo = args.original_repo, args.repo
+    old_publisher, new_publisher = args.original_publisher, args.publisher
 
     require_project_root()
     require_valid_java_package(new_pkg_id)
@@ -365,6 +434,10 @@ def main():
     if new_repo != old_repo:
         log_step("Rename repository references")
         rename_repository(old_repo, new_repo, files)
+
+    if new_publisher != old_publisher:
+        log_step("Rename publisher")
+        rename_publisher(old_publisher, new_publisher, files)
 
     if new_pkg_id != old_pkg_id:
         # Structural changes come last, so every pass above saw the old paths.

--- a/tool/build/rename.py
+++ b/tool/build/rename.py
@@ -1,15 +1,22 @@
 #!/usr/bin/env python3
-"""Rename the Flutter project identity (package, display name, and repository).
+"""Rewrite the project identity from the upstream names to the fork names.
 
-The tree intentionally keeps upstream identifiers to ease merges; this script
-is the build-time step that rewrites the whole tree to the fork identity:
-Dart package, bundle id (dotted/slash + source dirs + file names), display
-name, binary name, and repository references. Upstream attribution (license
-headers, credits, git dependency URLs) is preserved.
+The working tree deliberately keeps the upstream identifiers so that merges
+from upstream stay conflict-free. This script is the build step that swaps
+them for the fork identity across every platform, in five passes:
 
-全平台统一使用 --pkg-id（org.frblanapps.pilisuper），它同时也是 Android 的
-namespace 与 Java/Kotlin 源码包，因此必须是合法的 Java 包名（不含保留字；
-例如 com.pili.super 中的 super 会导致编译失败）。
+    dart package   package:PiliPlus/...     ->  package:PiliSuper/...
+    display name   "PiliPlus" labels        ->  "PiliSuper"
+    binary name    piliplus executables     ->  pilisuper
+    bundle id      com.example.piliplus     ->  org.frblanapps.pilisuper
+    repository     bggRGjQaUbCoE/PiliPlus   ->  FRBLanApps/PiliSuper
+
+Upstream attribution survives on purpose: license headers, credit lines and
+git dependency URLs keep naming PiliPlus and bggRGjQaUbCoE.
+
+--pkg-id doubles as the Android namespace and the Java/Kotlin source package,
+so it must be a legal Java package name。com.pili.super 会被拒绝，因为 super
+是 Java/Kotlin 保留字，用作 namespace 会导致 Android 构建失败。
 """
 from __future__ import annotations
 
@@ -17,23 +24,31 @@ import argparse
 import os
 import re
 import shutil
+from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable
 
 from build_common import (log_error, log_info, log_step, log_success,
                           log_warning, require_project_root)
 
-SKIP_DIRECTORIES = {".git", ".codegraph", ".dart_tool", ".omo", ".pytest_cache",
-                    ".fvm", ".idea", "build", "dist", "node_modules", "Pods",
-                    "ephemeral"}
+SELF_PATH = Path(__file__).resolve()
 
-# 仓库引用替换时整行跳过的上游署名标记（README 致谢、issue 模板的“上游 issue”链接）。
+# Never walked: VCS metadata, tool caches and build output.
+SKIP_DIRECTORIES = frozenset({
+    ".git", ".codegraph", ".dart_tool", ".omo", ".pytest_cache", ".fvm",
+    ".idea", "build", "dist", "node_modules", "Pods", "ephemeral",
+})
+
+# Hand-maintained, because it mixes fork links with upstream credits.
+MANUAL_FILES = frozenset({"README.md"})
+
+# A line that credits upstream keeps pointing at the upstream repository.
 ATTRIBUTION_LINE = re.compile(r"致敬|原作者|上上游|上游|[Uu]pstream|[Aa]cknowledg")
-# README 同时包含自仓引用与上游致谢，人工维护，不参与自动替换。
-MANUAL_FILES = {"README.md"}
 
-# Java/Kotlin 保留字：包名（同时是 Android namespace）段不允许出现。
-RESERVED_WORDS = {
+PACKAGE_SEGMENT = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+# Java/Kotlin keywords; a package segment may not be one of them.
+RESERVED_WORDS = frozenset({
     "abstract", "assert", "boolean", "break", "byte", "case", "catch", "char",
     "class", "const", "continue", "default", "do", "double", "else", "enum",
     "extends", "final", "finally", "float", "for", "fun", "goto", "if",
@@ -43,31 +58,125 @@ RESERVED_WORDS = {
     "return", "sealed", "short", "static", "strictfp", "super", "switch",
     "synchronized", "this", "throw", "throws", "transient", "try", "typealias",
     "val", "var", "vararg", "void", "volatile", "when", "where", "while",
-}
-
-SELF_PATH = Path(__file__).resolve()
+})
 
 
-def validate_package(pkg_id: str) -> None:
+def binary_name(app_name: str) -> str:
+    """Executable and desktop-entry spelling of an app name: PiliSuper -> pilisuper."""
+    return re.sub(r"[^a-z0-9.+-]", "-", app_name.lower())
+
+
+@dataclass(frozen=True, slots=True)
+class Swap:
+    """One old -> new identifier pair."""
+
+    old: str
+    new: str
+
+    @property
+    def changed(self) -> bool:
+        return self.old != self.new
+
+    def as_path(self) -> Swap:
+        """The same pair written as a path: com.example.x -> com/example/x."""
+        return Swap(self.old.replace(".", "/"), self.new.replace(".", "/"))
+
+
+@dataclass(frozen=True, slots=True)
+class Guard:
+    """Text spans that a rename pass must leave byte-for-byte intact.
+
+    `PiliPlus` also hides inside `com.example.PiliPlus` and
+    `bggRGjQaUbCoE/PiliPlus`, so renaming the display name blindly would
+    corrupt the bundle id and the upstream link. Those spans are reserved
+    first, and any substitution overlapping one is skipped.
+    """
+
+    reserved: re.Pattern[str] | None
+
+    @classmethod
+    def over(cls, *phrases: str) -> Guard:
+        wanted = [re.escape(phrase) for phrase in phrases if phrase]
+        if not wanted:
+            return cls(None)
+        return cls(re.compile("|".join(wanted), re.IGNORECASE))
+
+    def sub(
+        self,
+        pattern: re.Pattern[str],
+        replace: Callable[[re.Match[str]], str],
+        text: str,
+    ) -> str:
+        if self.reserved is None:
+            return pattern.sub(replace, text)
+        spans = [match.span() for match in self.reserved.finditer(text)]
+
+        def replace_unless_reserved(match: re.Match[str]) -> str:
+            start, end = match.span()
+            overlaps = any(start < stop and begin < end for begin, stop in spans)
+            return match.group(0) if overlaps else replace(match)
+
+        return pattern.sub(replace_unless_reserved, text)
+
+
+@dataclass(frozen=True, slots=True)
+class Identity:
+    """The three identifiers the rename is driven by, plus their derived forms."""
+
+    app_name: Swap
+    package: Swap
+    repository: Swap
+
+    @property
+    def dart_import(self) -> Swap:
+        return Swap(f"package:{self.app_name.old}/", f"package:{self.app_name.new}/")
+
+    @property
+    def binary(self) -> Swap:
+        return Swap(binary_name(self.app_name.old), binary_name(self.app_name.new))
+
+    @property
+    def package_path(self) -> Swap:
+        """Slash form, as used by JNI class paths and source directories."""
+        return self.package.as_path()
+
+    @property
+    def guard(self) -> Guard:
+        return Guard.over(
+            self.package.old, self.package_path.old, self.repository.old
+        )
+
+
+def require_valid_java_package(pkg_id: str) -> None:
     for segment in pkg_id.split("."):
-        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", segment) or segment in RESERVED_WORDS:
-            log_error(f"{pkg_id} 不是合法的 Java/Kotlin 包名（含保留字或非法段），将导致 Android 构建失败。")
-            raise SystemExit(1)
+        if PACKAGE_SEGMENT.fullmatch(segment) and segment not in RESERVED_WORDS:
+            continue
+        log_error(
+            f"{pkg_id} 不是合法的 Java/Kotlin 包名（含保留字或非法段），将导致 Android 构建失败。"
+        )
+        raise SystemExit(1)
 
 
-def iter_project_files() -> list[Path]:
-    files: list[Path] = []
-    for root, directories, names in os.walk("."):
-        directories[:] = sorted(d for d in directories if d not in SKIP_DIRECTORIES)
+def project_files() -> list[Path]:
+    """Every file in the tree, skipping caches, build output and this script."""
+    found: list[Path] = []
+    for directory, subdirectories, names in os.walk("."):
+        subdirectories[:] = sorted(
+            name for name in subdirectories if name not in SKIP_DIRECTORIES
+        )
         for name in names:
-            path = Path(root) / name
-            if path.resolve() == SELF_PATH:
-                continue
-            files.append(path)
-    return files
+            path = Path(directory) / name
+            if path.resolve() != SELF_PATH:
+                found.append(path)
+    return found
+
+
+def files_under(files: list[Path], *top_level: str) -> list[Path]:
+    return [path for path in files if path.parts[0] in top_level]
 
 
 def read_text(path: Path) -> str | None:
+    """Contents with line endings kept verbatim, or None if the file is not text."""
     try:
         with path.open(encoding="utf-8", newline="") as handle:
             return handle.read()
@@ -80,218 +189,176 @@ def write_text(path: Path, content: str) -> None:
         handle.write(content)
 
 
-def transform_files(transform: Callable[[str], str], files: list[Path]) -> None:
+def rewrite(files: list[Path], rewriter: Callable[[str], str]) -> None:
+    """Apply `rewriter` to every readable file, saving only actual changes."""
     for path in files:
-        content = read_text(path)
-        if content is None:
+        before = read_text(path)
+        if before is None:
             continue
-        updated = transform(content)
-        if updated != content:
-            write_text(path, updated)
+        after = rewriter(before)
+        if after != before:
+            write_text(path, after)
             log_info(f"updated: {path}")
 
 
-def protected_spans(
-    text: str, original_pkg_id: str, original_repo: str
-) -> list[tuple[int, int]]:
-    """Spans of old identifiers (bundle id, slash form, repo path) that
-    display-name/binary-name replacement must never touch — otherwise
-    bggRGjQaUbCoE/PiliPlus would be corrupted into bggRGjQaUbCoE/PiliSuper."""
-    identities = [original_pkg_id, original_pkg_id.replace(".", "/")]
-    if original_repo:
-        identities.append(original_repo)
-    pattern = "|".join(re.escape(identity) for identity in identities if identity)
-    if not pattern:
-        return []
-    return [match.span() for match in re.finditer(pattern, text, re.IGNORECASE)]
+def declares_display_label(path: Path) -> bool:
+    """Files whose plain text carries the user-visible app name."""
+    parts = path.parts
+    top, name = parts[0], path.name
+    return any((
+        name == "AndroidManifest.xml" and "android" in parts,
+        name == "string.xml"
+        and "res" in parts
+        and any(part.startswith("values") for part in parts),
+        top == "android" and "gradle" in name,
+        top in {"ios", "macos"} and name.endswith(".plist"),
+        name == "AppInfo.xcconfig",
+        parts[:3] == ("windows", "packaging", "exe") and name == "make_config.yaml",
+        parts[:2] == ("assets", "linux"),
+        top == ".vscode" and name.endswith(".json"),
+    ))
 
 
-def replace_word(text: str, old: str, new: str, protected: list[tuple[int, int]]) -> str:
-    """Whole-word replace that never touches bundle-id spans (com.example.PiliPlus)."""
+def rename_dart_package(identity: Identity, files: list[Path]) -> None:
+    """Every `package:PiliPlus/...` import, plus pubspec's own `name:` field."""
+    dart_import = identity.dart_import
+    rewrite(files, lambda text: text.replace(dart_import.old, dart_import.new))
 
-    def substitute(match: re.Match) -> str:
-        start, end = match.span()
-        if any(start < span_end and span_start < end for span_start, span_end in protected):
-            return match.group(0)
-        return new
-
-    return re.sub(rf"\b{re.escape(old)}\b", substitute, text)
-
-
-def rename_dart_package(app_name: str, original_app_name: str, files: list[Path]) -> None:
-    old_import = f"package:{original_app_name}/"
-    new_import = f"package:{app_name}/"
-    transform_files(lambda text: text.replace(old_import, new_import), files)
     pubspec = Path("pubspec.yaml")
-    content = read_text(pubspec)
-    if content is None:
+    declared = read_text(pubspec)
+    if declared is None:
         return
-    updated = re.sub(
-        rf"^(name:\s*){re.escape(original_app_name)}\b",
-        rf"\g<1>{app_name}",
-        content,
+    renamed = re.sub(
+        rf"^(name:\s*){re.escape(identity.app_name.old)}\b",
+        rf"\g<1>{identity.app_name.new}",
+        declared,
         count=1,
         flags=re.MULTILINE,
     )
-    if updated != content:
-        write_text(pubspec, updated)
+    if renamed != declared:
+        write_text(pubspec, renamed)
         log_info("updated: pubspec.yaml")
 
 
-def rename_bundle_id(pkg_id: str, original_pkg_id: str, files: list[Path]) -> None:
-    old_slash = original_pkg_id.replace(".", "/")
-    new_slash = pkg_id.replace(".", "/")
-    pattern = re.compile(
-        "|".join(re.escape(form) for form in {original_pkg_id, old_slash}),
-        re.IGNORECASE,
+def rename_display_name(identity: Identity, files: list[Path]) -> None:
+    """The user-visible name.
+
+    Platform label files get it replaced wherever it stands as a word; Dart
+    sources only inside string literals, so comments and license headers keep
+    saying PiliPlus.
+    """
+    app_name, guard = identity.app_name, identity.guard
+
+    word = re.compile(rf"\b{re.escape(app_name.old)}\b")
+    rewrite(
+        [path for path in files if declares_display_label(path)],
+        lambda text: guard.sub(word, lambda _: app_name.new, text),
     )
 
-    def substitute(match: re.Match) -> str:
-        return new_slash if "/" in match.group(0) else pkg_id
-
-    transform_files(lambda text: pattern.sub(substitute, text), files)
-
-
-def _display_label_file(path: Path) -> bool:
-    parts = path.parts
-    name = path.name
-    if name == "AndroidManifest.xml" and "android" in parts:
-        return True
-    if name == "string.xml" and "res" in parts and any(part.startswith("values") for part in parts):
-        return True
-    if "gradle" in name and parts[0] == "android":
-        return True
-    if name.endswith(".plist") and parts[0] in {"ios", "macos"}:
-        return True
-    if name == "AppInfo.xcconfig":
-        return True
-    if name == "make_config.yaml" and parts[:3] == ("windows", "packaging", "exe"):
-        return True
-    if parts[:2] == ("assets", "linux"):
-        return True
-    return parts[0] == ".vscode" and name.endswith(".json")
+    literal = re.compile(rf"(['\"]){re.escape(app_name.old)}\1")
+    rewrite(
+        files_under(files, "lib", "test"),
+        lambda text: guard.sub(
+            literal, lambda match: f"{match[1]}{app_name.new}{match[1]}", text
+        ),
+    )
 
 
-def rename_display_name(
-    app_name: str,
-    original_app_name: str,
-    original_pkg_id: str,
-    original_repo: str,
-    files: list[Path],
-) -> None:
-    def word_transform(text: str) -> str:
-        return replace_word(
-            text,
-            original_app_name,
-            app_name,
-            protected_spans(text, original_pkg_id, original_repo),
-        )
-
-    transform_files(word_transform, [path for path in files if _display_label_file(path)])
-
-    # lib/test 内的显示名只出现在字符串字面量里（constants.dart 的 appName）；
-    # GPL 头、注释里的 PiliPlus 是上游内容，保持不动。
-    quoted = re.compile(rf"(['\"]){re.escape(original_app_name)}\1")
-
-    def quoted_transform(text: str) -> str:
-        protected = protected_spans(text, original_pkg_id, original_repo)
-
-        def substitute(match: re.Match) -> str:
-            start, end = match.span()
-            if any(start < span_end and span_start < end for span_start, span_end in protected):
-                return match.group(0)
-            return f"{match.group(1)}{app_name}{match.group(1)}"
-
-        return quoted.sub(substitute, text)
-
-    transform_files(quoted_transform, [p for p in files if p.parts[0] in {"lib", "test"}])
-
-
-def normalize_binary_name(name: str) -> str:
-    return re.sub(r"[^a-z0-9.+-]", "-", name.lower())
-
-
-def rename_binary_name(
-    app_name: str,
-    original_app_name: str,
-    original_pkg_id: str,
-    original_repo: str,
-    files: list[Path],
-) -> None:
-    old_binary = normalize_binary_name(original_app_name)
-    new_binary = normalize_binary_name(app_name)
-    if old_binary == new_binary:
+def rename_binary_name(identity: Identity, files: list[Path]) -> None:
+    """The executable name: CMake targets, window titles, launcher scripts, and
+    the `piliplus_...` prefix of exported settings files."""
+    binary, guard = identity.binary, identity.guard
+    if not binary.changed:
         return
 
-    def word_transform(text: str) -> str:
-        return replace_word(
-            text,
-            old_binary,
-            new_binary,
-            protected_spans(text, original_pkg_id, original_repo),
+    word = re.compile(rf"\b{re.escape(binary.old)}\b")
+    rewrite(
+        files_under(files, "linux", "windows", "macos", "assets"),
+        lambda text: guard.sub(word, lambda _: binary.new, text),
+    )
+
+    literal_prefix = re.compile(rf"(['\"]){re.escape(binary.old)}")
+    rewrite(
+        files_under(files, "lib", "test"),
+        lambda text: literal_prefix.sub(rf"\g<1>{binary.new}", text),
+    )
+
+
+def rename_bundle_id(identity: Identity, files: list[Path]) -> None:
+    """Both spellings of the old id, case-insensitively: the dotted form used by
+    gradle, plists and CMake, and the slash form used by JNI class paths."""
+    dotted, path_form = identity.package, identity.package_path
+    spellings = re.compile(
+        f"{re.escape(dotted.old)}|{re.escape(path_form.old)}", re.IGNORECASE
+    )
+
+    def to_new_spelling(match: re.Match[str]) -> str:
+        return path_form.new if "/" in match.group(0) else dotted.new
+
+    rewrite(files, lambda text: spellings.sub(to_new_spelling, text))
+
+
+def rename_repository(identity: Identity, files: list[Path]) -> None:
+    """Fork links, decided line by line: a line crediting upstream keeps its
+    upstream link, and README.md is left to humans entirely."""
+    repository = identity.repository
+
+    def relink(text: str) -> str:
+        if repository.old not in text:
+            return text
+        return "".join(
+            line
+            if ATTRIBUTION_LINE.search(line)
+            else line.replace(repository.old, repository.new)
+            for line in text.splitlines(keepends=True)
         )
 
-    transform_files(
-        word_transform,
-        [p for p in files if p.parts[0] in {"linux", "windows", "macos", "assets"}],
-    )
-
-    # lib/test 内以旧二进制名开头的字符串字面量（备份/导出文件名前缀）。
-    prefix = re.compile(rf"(['\"]){re.escape(old_binary)}")
-
-    transform_files(
-        lambda text: prefix.sub(rf"\g<1>{new_binary}", text),
-        [p for p in files if p.parts[0] in {"lib", "test"}],
-    )
+    rewrite([path for path in files if path.name not in MANUAL_FILES], relink)
 
 
-def rename_repository(repo: str, original_repo: str, files: list[Path]) -> None:
-    def transform(text: str) -> str:
-        if original_repo not in text:
-            return text
-        updated = []
-        for line in text.splitlines(keepends=True):
-            if original_repo in line and not ATTRIBUTION_LINE.search(line):
-                line = line.replace(original_repo, repo)
-            updated.append(line)
-        return "".join(updated)
-
-    transform_files(transform, [p for p in files if p.name not in MANUAL_FILES])
+def remove_empty_parents(leaf: Path) -> None:
+    """Delete the leftover `.../com/example` chain once the package moved out."""
+    directory = leaf
+    while directory != Path(".") and directory.is_dir() and not any(directory.iterdir()):
+        directory.rmdir()
+        directory = directory.parent
 
 
-def _prune_empty_directories(directory: Path) -> None:
-    current = directory
-    while current != Path(".") and current.is_dir() and not any(current.iterdir()):
-        current.rmdir()
-        current = current.parent
+def find_package_directories(package_path: str) -> list[Path]:
+    found: list[Path] = []
+    for directory, subdirectories, _names in os.walk("."):
+        subdirectories[:] = sorted(
+            name for name in subdirectories if name not in SKIP_DIRECTORIES
+        )
+        location = Path(directory).as_posix()
+        if location == package_path or location.endswith(f"/{package_path}"):
+            found.append(Path(directory))
+            subdirectories[:] = []  # the package folder is the leaf we move
+    return found
 
 
-def move_package_directories(old_slash: str, new_slash: str) -> None:
-    sources: list[Path] = []
-    for root, directories, _names in os.walk("."):
-        directories[:] = sorted(d for d in directories if d not in SKIP_DIRECTORIES)
-        posix = Path(root).as_posix()
-        if posix != "." and (posix == old_slash or posix.endswith("/" + old_slash)):
-            sources.append(Path(root))
-            directories[:] = []
-    for source in sources:
-        relative = source.as_posix()
-        target = Path(relative[: relative.rfind(old_slash)] + new_slash)
+def move_source_directories(identity: Identity) -> None:
+    """Relocate `.../com/example/piliplus/` source folders to the new package."""
+    old_path, new_path = identity.package_path.old, identity.package_path.new
+    for source in find_package_directories(old_path):
+        location = source.as_posix()
+        target = Path(location[: location.rfind(old_path)] + new_path)
         if target.exists():
             log_warning(f"跳过目录移动，目标已存在: {target}")
             continue
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.move(str(source), str(target))
-        _prune_empty_directories(source.parent)
+        remove_empty_parents(source.parent)
         log_info(f"moved: {source} -> {target}")
 
 
-def rename_identity_files(pkg_id: str, original_pkg_id: str) -> None:
-    pattern = re.compile(re.escape(original_pkg_id), re.IGNORECASE)
-    for path in iter_project_files():
-        if not pattern.search(path.name):
+def rename_identity_files(identity: Identity) -> None:
+    """Files named after the bundle id, such as `com.example.piliplus.desktop`."""
+    old_id = re.compile(re.escape(identity.package.old), re.IGNORECASE)
+    for path in project_files():
+        if not old_id.search(path.name):
             continue
-        target = path.with_name(pattern.sub(pkg_id, path.name))
+        target = path.with_name(old_id.sub(identity.package.new, path.name))
         if target.exists():
             log_warning(f"跳过文件重命名，目标已存在: {target}")
             continue
@@ -299,7 +366,7 @@ def rename_identity_files(pkg_id: str, original_pkg_id: str) -> None:
         log_info(f"renamed: {path} -> {target}")
 
 
-def main() -> None:
+def parse_identity() -> Identity:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--pkg-id", default="org.frblanapps.pilisuper")
     parser.add_argument("--original-pkg-id", default="com.example.piliplus")
@@ -308,37 +375,42 @@ def main() -> None:
     parser.add_argument("--repo", default="FRBLanApps/PiliSuper")
     parser.add_argument("--original-repo", default="bggRGjQaUbCoE/PiliPlus")
     args = parser.parse_args()
+    return Identity(
+        app_name=Swap(args.original_app_name, args.app_name),
+        package=Swap(args.original_pkg_id, args.pkg_id),
+        repository=Swap(args.original_repo, args.repo),
+    )
 
+
+def main() -> None:
+    identity = parse_identity()
     require_project_root()
-    validate_package(args.pkg_id)
-    files = iter_project_files()
+    require_valid_java_package(identity.package.new)
 
-    if args.app_name != args.original_app_name:
+    # Listed once, before anything moves: the content passes below all work on
+    # pre-rename paths, and the structural passes walk the tree again themselves.
+    files = project_files()
+
+    if identity.app_name.changed:
         log_step("Rename Dart package")
-        rename_dart_package(args.app_name, args.original_app_name, files)
+        rename_dart_package(identity, files)
         log_step("Rename display name")
-        rename_display_name(
-            args.app_name, args.original_app_name, args.original_pkg_id, args.original_repo, files
-        )
+        rename_display_name(identity, files)
         log_step("Rename binary name")
-        rename_binary_name(
-            args.app_name, args.original_app_name, args.original_pkg_id, args.original_repo, files
-        )
+        rename_binary_name(identity, files)
 
-    if args.pkg_id != args.original_pkg_id:
+    if identity.package.changed:
         log_step("Rename bundle identifier")
-        rename_bundle_id(args.pkg_id, args.original_pkg_id, files)
+        rename_bundle_id(identity, files)
 
-    if args.repo != args.original_repo:
+    if identity.repository.changed:
         log_step("Rename repository references")
-        rename_repository(args.repo, args.original_repo, files)
+        rename_repository(identity, files)
 
-    if args.pkg_id != args.original_pkg_id:
-        # 结构性变更放在最后：前面的内容替换都基于原始路径进行。
-        move_package_directories(
-            args.original_pkg_id.replace(".", "/"), args.pkg_id.replace(".", "/")
-        )
-        rename_identity_files(args.pkg_id, args.original_pkg_id)
+    if identity.package.changed:
+        # Structural changes come last, so every pass above saw the old paths.
+        move_source_directories(identity)
+        rename_identity_files(identity)
 
     log_success("项目标识已更新")
 

--- a/tool/build/rename.py
+++ b/tool/build/rename.py
@@ -15,9 +15,20 @@ them for the fork identity across every platform, in six passes:
 Upstream attribution survives on purpose: license headers, credit lines and
 git dependency URLs keep naming PiliPlus and bggRGjQaUbCoE.
 
---pkg-id doubles as the Android namespace and the Java/Kotlin source package,
-so it must be a legal Java package name。com.pili.super 会被拒绝，因为 super
-是 Java/Kotlin 保留字，用作 namespace 会导致 Android 构建失败。
+--pkg-id serves every platform at once: the Android namespace and the
+Java/Kotlin source package, the Apple bundle identifier, and the Linux
+application id. Only the intersection of their rules is accepted, so a value
+that passes here cannot fail later in a platform build:
+
+    two or more segments   Android rejects a dotted-component-less id
+    letters and digits     Apple rejects `_`, Java/Kotlin rejects `-`
+    leading letter         Android rejects a segment starting with a digit
+    no reserved word       `super` as a namespace breaks the Android build
+
+--app-name lands in the pubspec `name:` field, so it must be a Dart identifier
+that is not a Dart reserved word; `dart pub get` refuses the project outright
+otherwise. Dart's list barely overlaps the Java/Kotlin one, hence the separate
+table.
 """
 from __future__ import annotations
 
@@ -56,6 +67,19 @@ RESERVED_WORDS = {
     "val", "var", "vararg", "void", "volatile", "when", "where", "while",
 }
 
+# Words `dart pub get` refuses in the pubspec `name:` field, verified against
+# the Dart 3.44 SDK. Dart's built-in identifiers (`dynamic`, `factory`, `get`,
+# `static`, `typedef`, ...) are absent because pub accepts them.
+DART_RESERVED_WORDS = {
+    "abstract", "as", "assert", "await", "break", "case", "catch", "class",
+    "const", "continue", "covariant", "default", "deferred", "do", "else",
+    "enum", "export", "extends", "external", "final", "finally", "for", "hide",
+    "if", "implements", "import", "in", "interface", "is", "late", "library",
+    "mixin", "new", "on", "operator", "part", "required", "rethrow", "return",
+    "sealed", "set", "super", "switch", "this", "throw", "try", "type", "var",
+    "void", "while", "with", "yield",
+}
+
 # Runner fields that hold a user-visible label which `flutter create` seeded
 # from the lowercase project name instead of the display name. Pass 2 matches
 # the display name case-sensitively and so walks past `piliplus`, after which
@@ -81,13 +105,32 @@ RUNNER_TREES = {"windows", "linux", "macos"}
 # 基础工具：校验、遍历、读写、逐文件改写
 # ---------------------------------------------------------------------------
 
-def require_valid_java_package(pkg_id):
-    for segment in pkg_id.split("."):
-        legal = re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", segment)
-        if legal and segment not in RESERVED_WORDS:
-            continue
-        log_error(f"{pkg_id} 不是合法的 Java/Kotlin 包名（含保留字或非法段），将导致 Android 构建失败。")
+def require_valid_pkg_id(pkg_id):
+    def reject(reason):
+        log_error(f"{pkg_id} 不是合法的跨平台包名：{reason}，将导致构建失败。")
         raise SystemExit(1)
+
+    segments = pkg_id.split(".")
+    if len(segments) < 2:
+        reject("至少需要两段，Android applicationId 必须包含点分段")
+    for segment in segments:
+        if not re.fullmatch(r"[A-Za-z][A-Za-z0-9]*", segment):
+            reject(f"段 {segment!r} 必须以字母开头且只含字母与数字"
+                   "（Apple bundle id 不接受下划线，Java/Kotlin 包名不接受连字符）")
+        if segment in RESERVED_WORDS:
+            reject(f"段 {segment!r} 是 Java/Kotlin 保留字，不能用作 Android namespace")
+
+
+def require_valid_app_name(app_name):
+    def reject(reason):
+        log_error(f"{app_name} 不是合法的 Dart 包名：{reason}，dart pub get 将拒绝该项目。")
+        raise SystemExit(1)
+
+    if not re.fullmatch(r"[A-Za-z_$][A-Za-z0-9_$]*", app_name):
+        reject("必须是合法的 Dart 标识符（首字符为字母、下划线或 $，其余为字母、数字、"
+               "下划线或 $），不能含空格、连字符或点")
+    if app_name in DART_RESERVED_WORDS:
+        reject("是 Dart 保留字")
 
 
 def project_files():
@@ -413,7 +456,8 @@ def main():
     old_publisher, new_publisher = args.original_publisher, args.publisher
 
     require_project_root()
-    require_valid_java_package(new_pkg_id)
+    require_valid_pkg_id(new_pkg_id)
+    require_valid_app_name(new_app_name)
 
     # Listed once, before anything moves: the content passes below all work on
     # pre-rename paths, and the structural passes walk the tree again themselves.

--- a/tool/build/rename.py
+++ b/tool/build/rename.py
@@ -24,8 +24,6 @@ import argparse
 import os
 import re
 import shutil
-from collections.abc import Callable
-from dataclasses import dataclass
 from pathlib import Path
 
 from build_common import (log_error, log_info, log_step, log_success,
@@ -34,21 +32,18 @@ from build_common import (log_error, log_info, log_step, log_success,
 SELF_PATH = Path(__file__).resolve()
 
 # Never walked: VCS metadata, tool caches and build output.
-SKIP_DIRECTORIES = frozenset({
-    ".git", ".codegraph", ".dart_tool", ".omo", ".pytest_cache", ".fvm",
-    ".idea", "build", "dist", "node_modules", "Pods", "ephemeral",
-})
+SKIP_DIRECTORIES = {".git", ".codegraph", ".dart_tool", ".omo", ".pytest_cache",
+                    ".fvm", ".idea", "build", "dist", "node_modules", "Pods",
+                    "ephemeral"}
 
 # Hand-maintained, because it mixes fork links with upstream credits.
-MANUAL_FILES = frozenset({"README.md"})
+MANUAL_FILES = {"README.md"}
 
 # A line that credits upstream keeps pointing at the upstream repository.
 ATTRIBUTION_LINE = re.compile(r"致敬|原作者|上上游|上游|[Uu]pstream|[Aa]cknowledg")
 
-PACKAGE_SEGMENT = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
-
 # Java/Kotlin keywords; a package segment may not be one of them.
-RESERVED_WORDS = frozenset({
+RESERVED_WORDS = {
     "abstract", "assert", "boolean", "break", "byte", "case", "catch", "char",
     "class", "const", "continue", "default", "do", "double", "else", "enum",
     "extends", "final", "finally", "float", "for", "fun", "goto", "if",
@@ -58,112 +53,27 @@ RESERVED_WORDS = frozenset({
     "return", "sealed", "short", "static", "strictfp", "super", "switch",
     "synchronized", "this", "throw", "throws", "transient", "try", "typealias",
     "val", "var", "vararg", "void", "volatile", "when", "where", "while",
-})
+}
 
 
-def binary_name(app_name: str) -> str:
-    """Executable and desktop-entry spelling of an app name: PiliSuper -> pilisuper."""
-    return re.sub(r"[^a-z0-9.+-]", "-", app_name.lower())
+# ---------------------------------------------------------------------------
+# 基础工具：校验、遍历、读写、逐文件改写
+# ---------------------------------------------------------------------------
 
-
-@dataclass(frozen=True, slots=True)
-class Swap:
-    """One old -> new identifier pair."""
-
-    old: str
-    new: str
-
-    @property
-    def changed(self) -> bool:
-        return self.old != self.new
-
-    def as_path(self) -> Swap:
-        """The same pair written as a path: com.example.x -> com/example/x."""
-        return Swap(self.old.replace(".", "/"), self.new.replace(".", "/"))
-
-
-@dataclass(frozen=True, slots=True)
-class Guard:
-    """Text spans that a rename pass must leave byte-for-byte intact.
-
-    `PiliPlus` also hides inside `com.example.PiliPlus` and
-    `bggRGjQaUbCoE/PiliPlus`, so renaming the display name blindly would
-    corrupt the bundle id and the upstream link. Those spans are reserved
-    first, and any substitution overlapping one is skipped.
-    """
-
-    reserved: re.Pattern[str] | None
-
-    @classmethod
-    def over(cls, *phrases: str) -> Guard:
-        wanted = [re.escape(phrase) for phrase in phrases if phrase]
-        if not wanted:
-            return cls(None)
-        return cls(re.compile("|".join(wanted), re.IGNORECASE))
-
-    def sub(
-        self,
-        pattern: re.Pattern[str],
-        replace: Callable[[re.Match[str]], str],
-        text: str,
-    ) -> str:
-        if self.reserved is None:
-            return pattern.sub(replace, text)
-        spans = [match.span() for match in self.reserved.finditer(text)]
-
-        def replace_unless_reserved(match: re.Match[str]) -> str:
-            start, end = match.span()
-            overlaps = any(start < stop and begin < end for begin, stop in spans)
-            return match.group(0) if overlaps else replace(match)
-
-        return pattern.sub(replace_unless_reserved, text)
-
-
-@dataclass(frozen=True, slots=True)
-class Identity:
-    """The three identifiers the rename is driven by, plus their derived forms."""
-
-    app_name: Swap
-    package: Swap
-    repository: Swap
-
-    @property
-    def dart_import(self) -> Swap:
-        return Swap(f"package:{self.app_name.old}/", f"package:{self.app_name.new}/")
-
-    @property
-    def binary(self) -> Swap:
-        return Swap(binary_name(self.app_name.old), binary_name(self.app_name.new))
-
-    @property
-    def package_path(self) -> Swap:
-        """Slash form, as used by JNI class paths and source directories."""
-        return self.package.as_path()
-
-    @property
-    def guard(self) -> Guard:
-        return Guard.over(
-            self.package.old, self.package_path.old, self.repository.old
-        )
-
-
-def require_valid_java_package(pkg_id: str) -> None:
+def require_valid_java_package(pkg_id):
     for segment in pkg_id.split("."):
-        if PACKAGE_SEGMENT.fullmatch(segment) and segment not in RESERVED_WORDS:
+        legal = re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", segment)
+        if legal and segment not in RESERVED_WORDS:
             continue
-        log_error(
-            f"{pkg_id} 不是合法的 Java/Kotlin 包名（含保留字或非法段），将导致 Android 构建失败。"
-        )
+        log_error(f"{pkg_id} 不是合法的 Java/Kotlin 包名（含保留字或非法段），将导致 Android 构建失败。")
         raise SystemExit(1)
 
 
-def project_files() -> list[Path]:
+def project_files():
     """Every file in the tree, skipping caches, build output and this script."""
-    found: list[Path] = []
+    found = []
     for directory, subdirectories, names in os.walk("."):
-        subdirectories[:] = sorted(
-            name for name in subdirectories if name not in SKIP_DIRECTORIES
-        )
+        subdirectories[:] = sorted(n for n in subdirectories if n not in SKIP_DIRECTORIES)
         for name in names:
             path = Path(directory) / name
             if path.resolve() != SELF_PATH:
@@ -171,11 +81,7 @@ def project_files() -> list[Path]:
     return found
 
 
-def files_under(files: list[Path], *top_level: str) -> list[Path]:
-    return [path for path in files if path.parts[0] in top_level]
-
-
-def read_text(path: Path) -> str | None:
+def read_text(path):
     """Contents with line endings kept verbatim, or None if the file is not text."""
     try:
         with path.open(encoding="utf-8", newline="") as handle:
@@ -184,12 +90,12 @@ def read_text(path: Path) -> str | None:
         return None
 
 
-def write_text(path: Path, content: str) -> None:
+def write_text(path, content):
     with path.open("w", encoding="utf-8", newline="") as handle:
         handle.write(content)
 
 
-def rewrite(files: list[Path], rewriter: Callable[[str], str]) -> None:
+def rewrite(files, rewriter):
     """Apply `rewriter` to every readable file, saving only actual changes."""
     for path in files:
         before = read_text(path)
@@ -201,36 +107,41 @@ def rewrite(files: list[Path], rewriter: Callable[[str], str]) -> None:
             log_info(f"updated: {path}")
 
 
-def declares_display_label(path: Path) -> bool:
-    """Files whose plain text carries the user-visible app name."""
-    parts = path.parts
-    top, name = parts[0], path.name
-    return any((
-        name == "AndroidManifest.xml" and "android" in parts,
-        name == "string.xml"
-        and "res" in parts
-        and any(part.startswith("values") for part in parts),
-        top == "android" and "gradle" in name,
-        top in {"ios", "macos"} and name.endswith(".plist"),
-        name == "AppInfo.xcconfig",
-        parts[:3] == ("windows", "packaging", "exe") and name == "make_config.yaml",
-        parts[:2] == ("assets", "linux"),
-        top == ".vscode" and name.endswith(".json"),
-    ))
+def spans_to_keep(text, *phrases):
+    """Where the old bundle id and the upstream repo path sit in `text`.
+
+    `PiliPlus` also hides inside `com.example.PiliPlus` and
+    `bggRGjQaUbCoE/PiliPlus`, so replacing the display name or the binary name
+    blindly would corrupt the bundle id and the upstream link. These spans get
+    located first; any match overlapping one is left alone.
+    """
+    wanted = [re.escape(phrase) for phrase in phrases if phrase]
+    if not wanted:
+        return []
+    return [m.span() for m in re.finditer("|".join(wanted), text, re.IGNORECASE)]
 
 
-def rename_dart_package(identity: Identity, files: list[Path]) -> None:
-    """Every `package:PiliPlus/...` import, plus pubspec's own `name:` field."""
-    dart_import = identity.dart_import
-    rewrite(files, lambda text: text.replace(dart_import.old, dart_import.new))
+def overlaps(span, spans_kept):
+    start, end = span
+    return any(start < stop and begin < end for begin, stop in spans_kept)
+
+
+# ---------------------------------------------------------------------------
+# Pass 1 —— Dart 包名：每个 import 加 pubspec 自己的 name 字段
+# ---------------------------------------------------------------------------
+
+def rename_dart_package(old_app_name, new_app_name, files):
+    old_import = f"package:{old_app_name}/"
+    new_import = f"package:{new_app_name}/"
+    rewrite(files, lambda text: text.replace(old_import, new_import))
 
     pubspec = Path("pubspec.yaml")
     declared = read_text(pubspec)
     if declared is None:
         return
     renamed = re.sub(
-        rf"^(name:\s*){re.escape(identity.app_name.old)}\b",
-        rf"\g<1>{identity.app_name.new}",
+        rf"^(name:\s*){re.escape(old_app_name)}\b",
+        rf"\g<1>{new_app_name}",
         declared,
         count=1,
         flags=re.MULTILINE,
@@ -240,83 +151,134 @@ def rename_dart_package(identity: Identity, files: list[Path]) -> None:
         log_info("updated: pubspec.yaml")
 
 
-def rename_display_name(identity: Identity, files: list[Path]) -> None:
-    """The user-visible name.
+# ---------------------------------------------------------------------------
+# Pass 2 —— 显示名：平台标签文件按词替换，Dart 只碰字符串字面量
+# ---------------------------------------------------------------------------
 
-    Platform label files get it replaced wherever it stands as a word; Dart
-    sources only inside string literals, so comments and license headers keep
-    saying PiliPlus.
+def declares_display_label(path):
+    """Files whose plain text carries the user-visible app name."""
+    parts = path.parts
+    top = parts[0]
+    name = path.name
+    if name == "AndroidManifest.xml" and "android" in parts:
+        return True
+    if name == "string.xml" and "res" in parts and any(p.startswith("values") for p in parts):
+        return True
+    if top == "android" and "gradle" in name:
+        return True
+    if top in {"ios", "macos"} and name.endswith(".plist"):
+        return True
+    if name == "AppInfo.xcconfig":
+        return True
+    if name == "make_config.yaml" and parts[:3] == ("windows", "packaging", "exe"):
+        return True
+    if parts[:2] == ("assets", "linux"):
+        return True
+    return top == ".vscode" and name.endswith(".json")
+
+
+def rename_display_name(old_app_name, new_app_name, old_pkg_id, old_repo, files):
+    """Platform label files get the name replaced wherever it stands as a word;
+    Dart sources only inside string literals, so comments and license headers
+    keep saying PiliPlus."""
+    old_pkg_path = old_pkg_id.replace(".", "/")
+    word = re.compile(rf"\b{re.escape(old_app_name)}\b")
+    quoted = re.compile(rf"(['\"]){re.escape(old_app_name)}\1")
+
+    def replace_words(text):
+        kept = spans_to_keep(text, old_pkg_id, old_pkg_path, old_repo)
+        return word.sub(lambda m: m[0] if overlaps(m.span(), kept) else new_app_name, text)
+
+    def replace_string_literals(text):
+        kept = spans_to_keep(text, old_pkg_id, old_pkg_path, old_repo)
+        return quoted.sub(
+            lambda m: m[0] if overlaps(m.span(), kept) else f"{m[1]}{new_app_name}{m[1]}",
+            text,
+        )
+
+    rewrite([p for p in files if declares_display_label(p)], replace_words)
+    rewrite([p for p in files if p.parts[0] in {"lib", "test"}], replace_string_literals)
+
+
+# ---------------------------------------------------------------------------
+# Pass 3 —— 二进制名：CMake target、窗口标题、启动脚本、导出文件名前缀
+# ---------------------------------------------------------------------------
+
+def binary_name(app_name):
+    """Executable / desktop-entry spelling: PiliSuper -> pilisuper.
+
+    Mirrors the normalization in packaging.py, so the .deb launcher and the
+    Linux bundle agree on one name.
     """
-    app_name, guard = identity.app_name, identity.guard
+    return re.sub(r"[^a-z0-9.+-]", "-", app_name.lower())
 
-    word = re.compile(rf"\b{re.escape(app_name.old)}\b")
+
+def rename_binary_name(old_app_name, new_app_name, old_pkg_id, old_repo, files):
+    old_binary = binary_name(old_app_name)
+    new_binary = binary_name(new_app_name)
+    if old_binary == new_binary:
+        return
+
+    old_pkg_path = old_pkg_id.replace(".", "/")
+    word = re.compile(rf"\b{re.escape(old_binary)}\b")
+    literal_prefix = re.compile(rf"(['\"]){re.escape(old_binary)}")
+
+    def replace_words(text):
+        kept = spans_to_keep(text, old_pkg_id, old_pkg_path, old_repo)
+        return word.sub(lambda m: m[0] if overlaps(m.span(), kept) else new_binary, text)
+
     rewrite(
-        [path for path in files if declares_display_label(path)],
-        lambda text: guard.sub(word, lambda _: app_name.new, text),
+        [p for p in files if p.parts[0] in {"linux", "windows", "macos", "assets"}],
+        replace_words,
+    )
+    rewrite(
+        [p for p in files if p.parts[0] in {"lib", "test"}],
+        lambda text: literal_prefix.sub(rf"\g<1>{new_binary}", text),
     )
 
-    literal = re.compile(rf"(['\"]){re.escape(app_name.old)}\1")
+
+# ---------------------------------------------------------------------------
+# Pass 4 —— Bundle id：点分形式（gradle/plist/CMake）与斜杠形式（JNI 类路径）
+# ---------------------------------------------------------------------------
+
+def rename_bundle_id(old_pkg_id, new_pkg_id, files):
+    old_pkg_path = old_pkg_id.replace(".", "/")
+    new_pkg_path = new_pkg_id.replace(".", "/")
+    either_spelling = re.compile(
+        f"{re.escape(old_pkg_id)}|{re.escape(old_pkg_path)}", re.IGNORECASE
+    )
+
     rewrite(
-        files_under(files, "lib", "test"),
-        lambda text: guard.sub(
-            literal, lambda match: f"{match[1]}{app_name.new}{match[1]}", text
+        files,
+        lambda text: either_spelling.sub(
+            lambda m: new_pkg_path if "/" in m[0] else new_pkg_id, text
         ),
     )
 
 
-def rename_binary_name(identity: Identity, files: list[Path]) -> None:
-    """The executable name: CMake targets, window titles, launcher scripts, and
-    the `piliplus_...` prefix of exported settings files."""
-    binary, guard = identity.binary, identity.guard
-    if not binary.changed:
-        return
+# ---------------------------------------------------------------------------
+# Pass 5 —— 仓库引用：逐行判断，致敬上游的那一行保留上游链接
+# ---------------------------------------------------------------------------
 
-    word = re.compile(rf"\b{re.escape(binary.old)}\b")
-    rewrite(
-        files_under(files, "linux", "windows", "macos", "assets"),
-        lambda text: guard.sub(word, lambda _: binary.new, text),
-    )
-
-    literal_prefix = re.compile(rf"(['\"]){re.escape(binary.old)}")
-    rewrite(
-        files_under(files, "lib", "test"),
-        lambda text: literal_prefix.sub(rf"\g<1>{binary.new}", text),
-    )
-
-
-def rename_bundle_id(identity: Identity, files: list[Path]) -> None:
-    """Both spellings of the old id, case-insensitively: the dotted form used by
-    gradle, plists and CMake, and the slash form used by JNI class paths."""
-    dotted, path_form = identity.package, identity.package_path
-    spellings = re.compile(
-        f"{re.escape(dotted.old)}|{re.escape(path_form.old)}", re.IGNORECASE
-    )
-
-    def to_new_spelling(match: re.Match[str]) -> str:
-        return path_form.new if "/" in match.group(0) else dotted.new
-
-    rewrite(files, lambda text: spellings.sub(to_new_spelling, text))
-
-
-def rename_repository(identity: Identity, files: list[Path]) -> None:
-    """Fork links, decided line by line: a line crediting upstream keeps its
-    upstream link, and README.md is left to humans entirely."""
-    repository = identity.repository
-
-    def relink(text: str) -> str:
-        if repository.old not in text:
+def rename_repository(old_repo, new_repo, files):
+    def relink(text):
+        if old_repo not in text:
             return text
-        return "".join(
-            line
-            if ATTRIBUTION_LINE.search(line)
-            else line.replace(repository.old, repository.new)
-            for line in text.splitlines(keepends=True)
-        )
+        lines = []
+        for line in text.splitlines(keepends=True):
+            if not ATTRIBUTION_LINE.search(line):
+                line = line.replace(old_repo, new_repo)
+            lines.append(line)
+        return "".join(lines)
 
-    rewrite([path for path in files if path.name not in MANUAL_FILES], relink)
+    rewrite([p for p in files if p.name not in MANUAL_FILES], relink)
 
 
-def remove_empty_parents(leaf: Path) -> None:
+# ---------------------------------------------------------------------------
+# 结构性变更：移动源码目录、重命名以 bundle id 命名的文件
+# ---------------------------------------------------------------------------
+
+def remove_empty_parents(leaf):
     """Delete the leftover `.../com/example` chain once the package moved out."""
     directory = leaf
     while directory != Path(".") and directory.is_dir() and not any(directory.iterdir()):
@@ -324,25 +286,22 @@ def remove_empty_parents(leaf: Path) -> None:
         directory = directory.parent
 
 
-def find_package_directories(package_path: str) -> list[Path]:
-    found: list[Path] = []
-    for directory, subdirectories, _names in os.walk("."):
-        subdirectories[:] = sorted(
-            name for name in subdirectories if name not in SKIP_DIRECTORIES
-        )
-        location = Path(directory).as_posix()
-        if location == package_path or location.endswith(f"/{package_path}"):
-            found.append(Path(directory))
-            subdirectories[:] = []  # the package folder is the leaf we move
-    return found
-
-
-def move_source_directories(identity: Identity) -> None:
+def move_source_directories(old_pkg_id, new_pkg_id):
     """Relocate `.../com/example/piliplus/` source folders to the new package."""
-    old_path, new_path = identity.package_path.old, identity.package_path.new
-    for source in find_package_directories(old_path):
+    old_pkg_path = old_pkg_id.replace(".", "/")
+    new_pkg_path = new_pkg_id.replace(".", "/")
+
+    sources = []
+    for directory, subdirectories, _names in os.walk("."):
+        subdirectories[:] = sorted(n for n in subdirectories if n not in SKIP_DIRECTORIES)
+        location = Path(directory).as_posix()
+        if location == old_pkg_path or location.endswith(f"/{old_pkg_path}"):
+            sources.append(Path(directory))
+            subdirectories[:] = []  # the package folder is the leaf we move
+
+    for source in sources:
         location = source.as_posix()
-        target = Path(location[: location.rfind(old_path)] + new_path)
+        target = Path(location[: location.rfind(old_pkg_path)] + new_pkg_path)
         if target.exists():
             log_warning(f"跳过目录移动，目标已存在: {target}")
             continue
@@ -352,13 +311,13 @@ def move_source_directories(identity: Identity) -> None:
         log_info(f"moved: {source} -> {target}")
 
 
-def rename_identity_files(identity: Identity) -> None:
+def rename_identity_files(old_pkg_id, new_pkg_id):
     """Files named after the bundle id, such as `com.example.piliplus.desktop`."""
-    old_id = re.compile(re.escape(identity.package.old), re.IGNORECASE)
+    old_id = re.compile(re.escape(old_pkg_id), re.IGNORECASE)
     for path in project_files():
         if not old_id.search(path.name):
             continue
-        target = path.with_name(old_id.sub(identity.package.new, path.name))
+        target = path.with_name(old_id.sub(new_pkg_id, path.name))
         if target.exists():
             log_warning(f"跳过文件重命名，目标已存在: {target}")
             continue
@@ -366,7 +325,11 @@ def rename_identity_files(identity: Identity) -> None:
         log_info(f"renamed: {path} -> {target}")
 
 
-def parse_identity() -> Identity:
+# ---------------------------------------------------------------------------
+# 入口
+# ---------------------------------------------------------------------------
+
+def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--pkg-id", default="org.frblanapps.pilisuper")
     parser.add_argument("--original-pkg-id", default="com.example.piliplus")
@@ -375,42 +338,38 @@ def parse_identity() -> Identity:
     parser.add_argument("--repo", default="FRBLanApps/PiliSuper")
     parser.add_argument("--original-repo", default="bggRGjQaUbCoE/PiliPlus")
     args = parser.parse_args()
-    return Identity(
-        app_name=Swap(args.original_app_name, args.app_name),
-        package=Swap(args.original_pkg_id, args.pkg_id),
-        repository=Swap(args.original_repo, args.repo),
-    )
 
+    old_app_name, new_app_name = args.original_app_name, args.app_name
+    old_pkg_id, new_pkg_id = args.original_pkg_id, args.pkg_id
+    old_repo, new_repo = args.original_repo, args.repo
 
-def main() -> None:
-    identity = parse_identity()
     require_project_root()
-    require_valid_java_package(identity.package.new)
+    require_valid_java_package(new_pkg_id)
 
     # Listed once, before anything moves: the content passes below all work on
     # pre-rename paths, and the structural passes walk the tree again themselves.
     files = project_files()
 
-    if identity.app_name.changed:
+    if new_app_name != old_app_name:
         log_step("Rename Dart package")
-        rename_dart_package(identity, files)
+        rename_dart_package(old_app_name, new_app_name, files)
         log_step("Rename display name")
-        rename_display_name(identity, files)
+        rename_display_name(old_app_name, new_app_name, old_pkg_id, old_repo, files)
         log_step("Rename binary name")
-        rename_binary_name(identity, files)
+        rename_binary_name(old_app_name, new_app_name, old_pkg_id, old_repo, files)
 
-    if identity.package.changed:
+    if new_pkg_id != old_pkg_id:
         log_step("Rename bundle identifier")
-        rename_bundle_id(identity, files)
+        rename_bundle_id(old_pkg_id, new_pkg_id, files)
 
-    if identity.repository.changed:
+    if new_repo != old_repo:
         log_step("Rename repository references")
-        rename_repository(identity, files)
+        rename_repository(old_repo, new_repo, files)
 
-    if identity.package.changed:
+    if new_pkg_id != old_pkg_id:
         # Structural changes come last, so every pass above saw the old paths.
-        move_source_directories(identity)
-        rename_identity_files(identity)
+        move_source_directories(old_pkg_id, new_pkg_id)
+        rename_identity_files(old_pkg_id, new_pkg_id)
 
     log_success("项目标识已更新")
 

--- a/tool/build/tests/test_build_scripts.py
+++ b/tool/build/tests/test_build_scripts.py
@@ -177,7 +177,7 @@ class PackagingTests(unittest.TestCase):
                 bundle,
                 root,
                 "PiliSuper",
-                packaging.package_identity("com.pili.super"),
+                packaging.package_identity("org.frblanapps.pilisuper"),
             )
 
             launcher = root / "usr" / "bin" / "pilisuper"
@@ -188,6 +188,12 @@ class PackagingTests(unittest.TestCase):
         identity = packaging.package_identity("org.example.client")
         self.assertEqual(identity.package_name, "org.example.client")
         self.assertEqual(identity.desktop_file_name, "org.example.client.desktop")
+
+    def test_legacy_com_pili_super_identity_keeps_pilisuper_branding(self):
+        identity = packaging.package_identity("com.pili.super")
+        self.assertEqual(identity.package_name, "pilisuper")
+        self.assertEqual(identity.desktop_file_name, "com.pili.super.desktop")
+        self.assertEqual(identity.icon_name, "pilisuper")
 
 
 class PrebuildTests(unittest.TestCase):

--- a/tool/build/tests/test_rename_script.py
+++ b/tool/build/tests/test_rename_script.py
@@ -109,19 +109,31 @@ def make_upstream_project() -> None:
           "PRODUCT_BUNDLE_IDENTIFIER = com.example.piliplus.RunnerTests;\n")
     write("macos/Runner/Configs/AppInfo.xcconfig",
           "PRODUCT_NAME = PiliPlus\n"
-          "PRODUCT_BUNDLE_IDENTIFIER = com.example.piliplus\n")
+          "PRODUCT_BUNDLE_IDENTIFIER = com.example.piliplus\n"
+          "PRODUCT_COPYRIGHT = Copyright © 2023 com.example. All rights reserved.\n")
     write("macos/Runner.xcodeproj/project.pbxproj", "path = piliplus.app;\n")
     write("linux/CMakeLists.txt",
           'set(BINARY_NAME "piliplus")\nset(APPLICATION_ID "com.example.piliplus")\n')
     write("linux/runner/my_application.cc",
+          'gtk_header_bar_set_title(header_bar, "piliplus");\n'
+          'gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));\n'
           'gtk_window_set_title(window, "piliplus");\n'
-          'g_settings_new("com.example.piliplus");\n')
+          'g_settings_new("com.example.piliplus");\n'
+          'g_build_filename(g_get_user_data_dir(), "com.example.piliplus", NULL);\n')
     write("windows/CMakeLists.txt",
           'project(piliplus LANGUAGES CXX)\nset(BINARY_NAME "piliplus")\n')
     write("windows/runner/main.cpp",
-          'if (!window.Create(L"piliplus", origin, size)) {\n')
+          '  HWND hwnd = ::FindWindow(L"FLUTTER_RUNNER_WIN32_WINDOW", L"piliplus");\n'
+          '  flutter::DartProject project(L"data");\n'
+          '  if (!window.Create(L"piliplus", origin, size)) {\n')
     write("windows/runner/Runner.rc",
-          'VALUE "OriginalFilename", "piliplus.exe" "\\0"\n')
+          '            VALUE "CompanyName", "com.example" "\\0"\n'
+          '            VALUE "FileDescription", "piliplus" "\\0"\n'
+          '            VALUE "InternalName", "piliplus" "\\0"\n'
+          '            VALUE "LegalCopyright", '
+          '"Copyright (C) 2023 com.example. All rights reserved." "\\0"\n'
+          '            VALUE "OriginalFilename", "piliplus.exe" "\\0"\n'
+          '            VALUE "ProductName", "piliplus" "\\0"\n')
     write("windows/packaging/exe/make_config.yaml",
           "display_name: PiliPlus\n"
           "publisher_url: https://github.com/bggRGjQaUbCoE/PiliPlus\n")
@@ -222,6 +234,7 @@ class FullRenameTests(RenameSandbox):
         xcconfig = read("macos/Runner/Configs/AppInfo.xcconfig")
         self.assertIn("PRODUCT_NAME = PiliSuper", xcconfig)
         self.assertIn(f"PRODUCT_BUNDLE_IDENTIFIER = {PKG_ID}", xcconfig)
+        self.assertIn("PRODUCT_COPYRIGHT = Copyright © 2023 FRBLanApps.", xcconfig)
         self.assertIn("path = pilisuper.app;",
                       read("macos/Runner.xcodeproj/project.pbxproj"))
 
@@ -229,14 +242,29 @@ class FullRenameTests(RenameSandbox):
         self.assertIn('set(BINARY_NAME "pilisuper")', linux_cmake)
         self.assertIn(f'set(APPLICATION_ID "{PKG_ID}")', linux_cmake)
         cc = read("linux/runner/my_application.cc")
-        self.assertIn('gtk_window_set_title(window, "pilisuper")', cc)
+        self.assertIn('gtk_window_set_title(window, "PiliSuper")', cc)
+        self.assertIn('gtk_header_bar_set_title(header_bar, "PiliSuper")', cc)
+        self.assertIn("gtk_window_set_titlebar(window, GTK_WIDGET(header_bar))", cc)
         self.assertIn(f'g_settings_new("{PKG_ID}")', cc)
+        self.assertIn(f'g_get_user_data_dir(), "{PKG_ID}"', cc)
 
         windows_cmake = read("windows/CMakeLists.txt")
         self.assertIn("project(pilisuper LANGUAGES CXX)", windows_cmake)
         self.assertIn('set(BINARY_NAME "pilisuper")', windows_cmake)
-        self.assertIn('L"pilisuper"', read("windows/runner/main.cpp"))
-        self.assertIn('"pilisuper.exe"', read("windows/runner/Runner.rc"))
+
+        main_cpp = read("windows/runner/main.cpp")
+        self.assertIn('::FindWindow(L"FLUTTER_RUNNER_WIN32_WINDOW", L"PiliSuper")',
+                      main_cpp)
+        self.assertIn('window.Create(L"PiliSuper", origin, size)', main_cpp)
+        self.assertIn('flutter::DartProject project(L"data")', main_cpp)
+
+        rc = read("windows/runner/Runner.rc")
+        self.assertIn('VALUE "FileDescription", "PiliSuper"', rc)
+        self.assertIn('VALUE "ProductName", "PiliSuper"', rc)
+        self.assertIn('VALUE "InternalName", "pilisuper"', rc)
+        self.assertIn('VALUE "OriginalFilename", "pilisuper.exe"', rc)
+        self.assertIn('VALUE "CompanyName", "FRBLanApps"', rc)
+        self.assertIn('VALUE "LegalCopyright", "Copyright (C) 2023 FRBLanApps.', rc)
 
         config = read("windows/packaging/exe/make_config.yaml")
         self.assertIn("display_name: PiliSuper", config)
@@ -329,6 +357,25 @@ class DisplayNameOnlyTests(RenameSandbox):
             "android/app/src/main/java/com/example/piliplus/AndroidHelper.java").is_file())
         self.assertTrue(Path("assets/linux/com.example.piliplus.desktop").is_file())
         self.assertIn("FRBLanApps/PiliSuper/releases", read("lib/http/api.dart"))
+
+        # 发行者与 bundle id 各自独立：署名换掉，包名保持原样。
+        rc = read("windows/runner/Runner.rc")
+        self.assertIn('VALUE "CompanyName", "FRBLanApps"', rc)
+        self.assertIn('VALUE "FileDescription", "PiliSuper"', rc)
+        self.assertIn('VALUE "OriginalFilename", "pilisuper.exe"', rc)
+        self.assertIn("Copyright © 2023 FRBLanApps.",
+                      read("macos/Runner/Configs/AppInfo.xcconfig"))
+
+
+class PublisherTests(RenameSandbox):
+    def test_publisher_untouched_when_unchanged(self):
+        run_rename("--publisher", "com.example")
+
+        rc = read("windows/runner/Runner.rc")
+        self.assertIn('VALUE "CompanyName", "com.example"', rc)
+        self.assertIn("Copyright (C) 2023 com.example.", rc)
+        self.assertIn("Copyright © 2023 com.example.",
+                      read("macos/Runner/Configs/AppInfo.xcconfig"))
 
 
 class ValidationTests(RenameSandbox):

--- a/tool/build/tests/test_rename_script.py
+++ b/tool/build/tests/test_rename_script.py
@@ -379,15 +379,53 @@ class PublisherTests(RenameSandbox):
 
 
 class ValidationTests(RenameSandbox):
-    def test_reserved_word_package_rejected(self):
+    def assertRejected(self, *argv: str) -> None:
         with self.assertRaises(SystemExit):
-            run_rename("--pkg-id", "com.pili.super")
+            run_rename(*argv)
         self.assertIn("name: PiliPlus", read("pubspec.yaml"))
 
+    def assertPkgIdRejected(self, pkg_id: str) -> None:
+        self.assertRejected("--pkg-id", pkg_id)
+
+    def assertAppNameRejected(self, app_name: str) -> None:
+        self.assertRejected("--app-name", app_name)
+
+    def test_reserved_word_package_rejected(self):
+        self.assertPkgIdRejected("com.pili.super")
+
     def test_invalid_segment_package_rejected(self):
-        with self.assertRaises(SystemExit):
-            run_rename("--pkg-id", "org.frblanapps.pili+super")
-        self.assertIn("name: PiliPlus", read("pubspec.yaml"))
+        self.assertPkgIdRejected("org.frblanapps.pili+super")
+
+    def test_single_segment_package_rejected(self):
+        self.assertPkgIdRejected("foo")
+
+    def test_underscore_package_rejected(self):
+        self.assertPkgIdRejected("org.example.my_app")
+
+    def test_hyphen_package_rejected(self):
+        self.assertPkgIdRejected("org.example.my-app")
+
+    def test_leading_digit_segment_rejected(self):
+        self.assertPkgIdRejected("org.example.2fast")
+
+    def test_empty_segment_rejected(self):
+        self.assertPkgIdRejected("org..example")
+
+    def test_dart_reserved_app_name_rejected(self):
+        for app_name in ("mixin", "class", "with", "await", "required", "type"):
+            with self.subTest(app_name=app_name):
+                self.assertAppNameRejected(app_name)
+
+    def test_non_identifier_app_name_rejected(self):
+        for app_name in ("Pili-Super", "Pili Super", "2fast", "Pili.Super",
+                         "Pili+Super", ""):
+            with self.subTest(app_name=app_name):
+                self.assertAppNameRejected(app_name)
+
+    def test_dart_builtin_identifier_app_name_accepted(self):
+        """`dart pub get` accepts built-in identifiers, so neither may this."""
+        run_rename("--app-name", "dynamic")
+        self.assertIn("name: dynamic", read("pubspec.yaml"))
 
 
 if __name__ == "__main__":

--- a/tool/build/tests/test_rename_script.py
+++ b/tool/build/tests/test_rename_script.py
@@ -326,6 +326,48 @@ class FullRenameTests(RenameSandbox):
             Path("crlf.txt").read_bytes(),
             b"id=org.frblanapps.pilisuper\r\nimport 'package:PiliSuper/x.dart';\r\n")
 
+    def test_symlinked_file_aborts_before_mutation(self):
+        external = tempfile.TemporaryDirectory()
+        self.addCleanup(external.cleanup)
+        outside = Path(external.name) / "outside.dart"
+        outside.write_text("const value = 'PiliPlus';\n", encoding="utf-8")
+        link = Path("lib/external.dart")
+        link.symlink_to(outside)
+
+        with self.assertRaises(SystemExit):
+            run_rename()
+
+        self.assertEqual(outside.read_text(encoding="utf-8"), "const value = 'PiliPlus';\n")
+        self.assertTrue(link.is_symlink())
+        self.assertIn("name: PiliPlus", read("pubspec.yaml"))
+        self.assertIn("package:PiliPlus/", read("lib/main.dart"))
+        self.assertFalse(Path("assets/linux/org.frblanapps.pilisuper.desktop").exists())
+
+    def test_directory_collision_aborts_before_mutation(self):
+        target = Path("android/app/src/main/kotlin/org/frblanapps/pilisuper")
+        target.mkdir(parents=True)
+        (target / "sentinel.txt").write_text("keep", encoding="utf-8")
+        original = read("android/app/src/main/kotlin/com/example/piliplus/MainActivity.kt")
+
+        with self.assertRaises(SystemExit):
+            run_rename()
+
+        self.assertTrue(Path("android/app/src/main/kotlin/com/example/piliplus/MainActivity.kt").is_file())
+        self.assertEqual(read("android/app/src/main/kotlin/com/example/piliplus/MainActivity.kt"), original)
+        self.assertEqual((target / "sentinel.txt").read_text(encoding="utf-8"), "keep")
+        self.assertIn("name: PiliPlus", read("pubspec.yaml"))
+
+    def test_identity_file_collision_aborts_before_mutation(self):
+        target = Path("assets/linux/org.frblanapps.pilisuper.desktop")
+        target.write_text("sentinel", encoding="utf-8")
+
+        with self.assertRaises(SystemExit):
+            run_rename()
+
+        self.assertTrue(Path("assets/linux/com.example.piliplus.desktop").is_file())
+        self.assertEqual(target.read_text(encoding="utf-8"), "sentinel")
+        self.assertIn("name: PiliPlus", read("pubspec.yaml"))
+
     def test_rename_is_idempotent(self):
         run_rename()
         snapshot = tree_snapshot()
@@ -426,6 +468,30 @@ class ValidationTests(RenameSandbox):
         """`dart pub get` accepts built-in identifiers, so neither may this."""
         run_rename("--app-name", "dynamic")
         self.assertIn("name: dynamic", read("pubspec.yaml"))
+
+
+class WorkflowTests(unittest.TestCase):
+    def test_user_inputs_are_not_embedded_in_shell_run_blocks(self):
+        workflow = BUILD_ROOT.parents[1] / ".github" / "workflows" / "build.yml"
+        lines = workflow.read_text(encoding="utf-8").splitlines()
+        in_run = False
+        run_indent = 0
+        shell_lines = []
+        for line in lines:
+            stripped = line.lstrip()
+            indent = len(line) - len(stripped)
+            if stripped.startswith("run:"):
+                in_run = True
+                run_indent = indent
+                shell_lines.append(stripped[4:])
+                continue
+            if in_run and stripped and indent <= run_indent:
+                in_run = False
+            if in_run:
+                shell_lines.append(line)
+
+        self.assertTrue(shell_lines)
+        self.assertNotIn("${{ inputs.", "\n".join(shell_lines))
 
 
 if __name__ == "__main__":

--- a/tool/build/tests/test_rename_script.py
+++ b/tool/build/tests/test_rename_script.py
@@ -1,0 +1,347 @@
+import importlib
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+BUILD_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BUILD_ROOT))
+
+rename = importlib.import_module("rename")
+
+PKG_ID = "org.frblanapps.pilisuper"
+CODE_PATH = "org/frblanapps/pilisuper"
+
+
+def write(relative: str, content: str) -> None:
+    path = Path(relative)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        handle.write(content)
+
+
+def read(relative: str) -> str:
+    with Path(relative).open(encoding="utf-8", newline="") as handle:
+        return handle.read()
+
+
+def make_upstream_project() -> None:
+    write("pubspec.yaml",
+          "name: PiliPlus\n\ndependencies:\n"
+          "  audio_service:\n    git:\n"
+          "      url: https://github.com/bggRGjQaUbCoE/audio_service.git\n")
+    write("lib/main.dart", "import 'package:PiliPlus/common/constants.dart';\n")
+    write("lib/common/constants.dart",
+          "abstract final class Constants {\n"
+          "  static const appName = 'PiliPlus';\n"
+          "  static const sourceCodeUrl = 'https://github.com/bggRGjQaUbCoE/PiliPlus';\n"
+          "}\n")
+    write("lib/gpl_header.dart",
+          "/*\n * This file is part of PiliPlus\n */\n"
+          "/// created by bggRGjQaUbCoE on 2025/6/27\n"
+          "import 'package:PiliPlus/main.dart';\n")
+    write("lib/http/api.dart",
+          "const releases = 'https://api.github.com/repos/bggRGjQaUbCoE/PiliPlus/releases';\n")
+    write("lib/services/audio_handler.dart",
+          "androidNotificationChannelId: 'com.example.piliplus.audio',\n")
+    write("lib/utils/android/bindings.g.dart",
+          "/// from: `com.example.piliplus.AndroidHelper`\n"
+          "class AndroidHelper {\n"
+          "  static const classPath = r'com/example/piliplus/AndroidHelper';\n"
+          "  String get signature => r'Lcom/example/piliplus/AndroidHelper;';\n"
+          "}\n")
+    write("lib/pages/backup.dart",
+          "return 'piliplus_settings_${DeviceUtils.platformName}.json';\n")
+    write("lib/pages/export.dart", "prefix: 'piliplus_${localFileName()}_',\n")
+    write("test/app_test.dart", "import 'package:PiliPlus/main.dart';\n")
+    write("tool/jnigen/jnigen.dart",
+          "classes: ['com.example.piliplus.AndroidHelper'],\n")
+    write("tool/patches/example.patch",
+          "--- a/lib/main.dart\n+++ b/lib/main.dart\n"
+          "@@\n-import 'package:PiliPlus/main.dart';\n")
+    write("android/app/build.gradle.kts",
+          'android {\n'
+          '    namespace = "com.example.piliplus"\n'
+          '    defaultConfig {\n'
+          '        applicationId = "com.example.piliplus"\n'
+          '    }\n'
+          '    buildTypes {\n'
+          '        debug {\n'
+          '            applicationIdSuffix = ".dev"\n'
+          '        }\n'
+          '    }\n'
+          '    productFlavors {\n'
+          '        create("dev") {\n'
+          '            resValue("string", "app_name", "PiliPlus dev")\n'
+          '        }\n'
+          '    }\n'
+          '}\n')
+    write("android/app/src/main/AndroidManifest.xml",
+          '<manifest xmlns:android="http://schemas.android.com/apk/res/android"\n'
+          '    package="com.example.piliplus">\n'
+          '    <application android:label="@string/app_name">\n'
+          '        <activity android:name=".MainActivity">\n'
+          '            <intent-filter android:label="PiliPlus">\n'
+          '                <action android:name="com.example.piliplus.SHORTCUT" />\n'
+          '            </intent-filter>\n'
+          '        </activity>\n'
+          '    </application>\n'
+          '</manifest>\n')
+    write("android/app/src/profile/AndroidManifest.xml",
+          '<manifest package="com.example.piliplus">\n</manifest>\n')
+    write("android/app/src/main/res/values/string.xml",
+          '<resources>\n    <string name="app_name">PiliPlus</string>\n</resources>\n')
+    write("android/app/src/debug/res/values/string.xml",
+          '<resources>\n    <string name="app_name">PiliPlus debug</string>\n</resources>\n')
+    write("android/app/src/main/res/xml-v25/shortcuts.xml",
+          '<shortcuts>\n    <intent android:action="com.example.piliplus.SHORTCUT" />\n</shortcuts>\n')
+    write("android/app/src/main/kotlin/com/example/piliplus/MainActivity.kt",
+          "package com.example.piliplus\n")
+    write("android/app/src/main/java/com/example/piliplus/AndroidHelper.java",
+          "package com.example.piliplus;\n")
+    write("ios/Runner/Info.plist",
+          "<dict>\n\t<key>CFBundleDisplayName</key>\n\t<string>PiliPlus</string>\n"
+          "\t<key>CFBundleName</key>\n\t<string>PiliPlus</string>\n</dict>\n")
+    write("ios/Runner.xcodeproj/project.pbxproj",
+          "PRODUCT_BUNDLE_IDENTIFIER = com.example.piliplus;\n"
+          "PRODUCT_BUNDLE_IDENTIFIER = com.example.piliplus.RunnerTests;\n")
+    write("macos/Runner/Configs/AppInfo.xcconfig",
+          "PRODUCT_NAME = PiliPlus\n"
+          "PRODUCT_BUNDLE_IDENTIFIER = com.example.piliplus\n")
+    write("macos/Runner.xcodeproj/project.pbxproj", "path = piliplus.app;\n")
+    write("linux/CMakeLists.txt",
+          'set(BINARY_NAME "piliplus")\nset(APPLICATION_ID "com.example.piliplus")\n')
+    write("linux/runner/my_application.cc",
+          'gtk_window_set_title(window, "piliplus");\n'
+          'g_settings_new("com.example.piliplus");\n')
+    write("windows/CMakeLists.txt",
+          'project(piliplus LANGUAGES CXX)\nset(BINARY_NAME "piliplus")\n')
+    write("windows/runner/main.cpp",
+          'if (!window.Create(L"piliplus", origin, size)) {\n')
+    write("windows/runner/Runner.rc",
+          'VALUE "OriginalFilename", "piliplus.exe" "\\0"\n')
+    write("windows/packaging/exe/make_config.yaml",
+          "display_name: PiliPlus\n"
+          "publisher_url: https://github.com/bggRGjQaUbCoE/PiliPlus\n")
+    write("assets/linux/com.example.piliplus.desktop",
+          "[Desktop Entry]\nName=PiliPlus\nExec=piliplus\nIcon=piliplus\n"
+          "StartupWMClass=com.example.piliplus\n")
+    write("assets/linux/DEBIAN/prerm",
+          'echo "Stopping PiliPlus if running..."\npkill -x piliplus || true\n')
+    write("assets/linux/DEBIAN/postrm",
+          "rm -rf /home/*/.local/share/com.example.PiliPlus || true\n")
+    write(".github/ISSUE_TEMPLATE/bug.yml",
+          "- label: 搜索了 [历史 issue](https://github.com/bggRGjQaUbCoE/PiliPlus/issues?q=is%3Aissue)\n"
+          "- label: 搜索了 [上游的历史 issue](https://github.com/bggRGjQaUbCoE/PiliPlus/issues?q=is%3Aissue)\n")
+    write(".vscode/launch.json",
+          '{\n  "configurations": [\n    {\n      "name": "PiliPlus"\n    }\n  ]\n}\n')
+    write("README.md",
+          "git clone https://github.com/bggRGjQaUbCoE/PiliPlus.git\n\n"
+          "在此致敬原作者：[bggRGjQaUbCoE/PiliPlus](https://github.com/bggRGjQaUbCoE/PiliPlus)\n")
+    write("build/skipme.txt", "package:PiliPlus/ com.example.piliplus\n")
+    write(".dart_tool/skipme.txt", "package:PiliPlus/\n")
+    Path("binary.png").write_bytes(b"\x89PNG\r\n\x1a\n\xff\xfe\x00piliplus")
+    Path("crlf.txt").write_bytes(
+        b"id=com.example.piliplus\r\nimport 'package:PiliPlus/x.dart';\r\n"
+    )
+
+
+def run_rename(*argv: str) -> None:
+    with patch.object(sys, "argv", ["rename.py", *argv]):
+        rename.main()
+
+
+def tree_snapshot() -> dict[str, bytes]:
+    snapshot: dict[str, bytes] = {}
+    for root, directories, names in os.walk("."):
+        directories[:] = sorted(directories)
+        for name in names:
+            path = Path(root) / name
+            snapshot[path.as_posix()] = path.read_bytes()
+    return snapshot
+
+
+class RenameSandbox(unittest.TestCase):
+    """Creates an upstream-named miniature Flutter project in a temp dir."""
+
+    def setUp(self):
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        previous = os.getcwd()
+        self.addCleanup(os.chdir, previous)
+        os.chdir(temp.name)
+        make_upstream_project()
+
+
+class FullRenameTests(RenameSandbox):
+    def test_covers_all_platforms(self):
+        run_rename()
+
+        self.assertIn("name: PiliSuper", read("pubspec.yaml"))
+        self.assertIn("package:PiliSuper/", read("lib/main.dart"))
+        self.assertIn("package:PiliSuper/", read("test/app_test.dart"))
+        self.assertIn("package:PiliSuper/", read("tool/patches/example.patch"))
+
+        gradle = read("android/app/build.gradle.kts")
+        self.assertIn(f'namespace = "{PKG_ID}"', gradle)
+        self.assertIn(f'applicationId = "{PKG_ID}"', gradle)
+        self.assertIn('applicationIdSuffix = ".dev"', gradle)
+        self.assertIn('"PiliSuper dev"', gradle)
+
+        manifest = read("android/app/src/main/AndroidManifest.xml")
+        self.assertIn(f'package="{PKG_ID}"', manifest)
+        self.assertIn('android:label="@string/app_name"', manifest)
+        self.assertIn('android:label="PiliSuper"', manifest)
+        self.assertIn(f'<action android:name="{PKG_ID}.SHORTCUT" />', manifest)
+        self.assertIn(f'package="{PKG_ID}"',
+                      read("android/app/src/profile/AndroidManifest.xml"))
+        self.assertIn(f'<intent android:action="{PKG_ID}.SHORTCUT" />',
+                      read("android/app/src/main/res/xml-v25/shortcuts.xml"))
+        self.assertIn('<string name="app_name">PiliSuper</string>',
+                      read("android/app/src/main/res/values/string.xml"))
+        self.assertIn('<string name="app_name">PiliSuper debug</string>',
+                      read("android/app/src/debug/res/values/string.xml"))
+
+        self.assertTrue(Path(
+            f"android/app/src/main/kotlin/{CODE_PATH}/MainActivity.kt").is_file())
+        java = Path(f"android/app/src/main/java/{CODE_PATH}/AndroidHelper.java")
+        self.assertTrue(java.is_file())
+        self.assertIn(f"package {PKG_ID};", read(str(java)))
+        self.assertIn(f"package {PKG_ID}",
+                      read(f"android/app/src/main/kotlin/{CODE_PATH}/MainActivity.kt"))
+        self.assertFalse(Path("android/app/src/main/java/com").exists())
+        self.assertFalse(Path("android/app/src/main/kotlin/com").exists())
+
+        self.assertIn("<string>PiliSuper</string>", read("ios/Runner/Info.plist"))
+        pbxproj = read("ios/Runner.xcodeproj/project.pbxproj")
+        self.assertIn(f"PRODUCT_BUNDLE_IDENTIFIER = {PKG_ID};", pbxproj)
+        self.assertIn(f"PRODUCT_BUNDLE_IDENTIFIER = {PKG_ID}.RunnerTests;", pbxproj)
+
+        xcconfig = read("macos/Runner/Configs/AppInfo.xcconfig")
+        self.assertIn("PRODUCT_NAME = PiliSuper", xcconfig)
+        self.assertIn(f"PRODUCT_BUNDLE_IDENTIFIER = {PKG_ID}", xcconfig)
+        self.assertIn("path = pilisuper.app;",
+                      read("macos/Runner.xcodeproj/project.pbxproj"))
+
+        linux_cmake = read("linux/CMakeLists.txt")
+        self.assertIn('set(BINARY_NAME "pilisuper")', linux_cmake)
+        self.assertIn(f'set(APPLICATION_ID "{PKG_ID}")', linux_cmake)
+        cc = read("linux/runner/my_application.cc")
+        self.assertIn('gtk_window_set_title(window, "pilisuper")', cc)
+        self.assertIn(f'g_settings_new("{PKG_ID}")', cc)
+
+        windows_cmake = read("windows/CMakeLists.txt")
+        self.assertIn("project(pilisuper LANGUAGES CXX)", windows_cmake)
+        self.assertIn('set(BINARY_NAME "pilisuper")', windows_cmake)
+        self.assertIn('L"pilisuper"', read("windows/runner/main.cpp"))
+        self.assertIn('"pilisuper.exe"', read("windows/runner/Runner.rc"))
+
+        config = read("windows/packaging/exe/make_config.yaml")
+        self.assertIn("display_name: PiliSuper", config)
+        self.assertIn("https://github.com/FRBLanApps/PiliSuper", config)
+
+        desktop = read(f"assets/linux/{PKG_ID}.desktop")
+        self.assertIn("Name=PiliSuper", desktop)
+        self.assertIn("Exec=pilisuper", desktop)
+        self.assertIn("Icon=pilisuper", desktop)
+        self.assertIn(f"StartupWMClass={PKG_ID}", desktop)
+        self.assertFalse(Path("assets/linux/com.example.piliplus.desktop").exists())
+
+        prerm = read("assets/linux/DEBIAN/prerm")
+        self.assertIn("Stopping PiliSuper", prerm)
+        self.assertIn("pkill -x pilisuper", prerm)
+        self.assertIn(f"share/{PKG_ID}", read("assets/linux/DEBIAN/postrm"))
+
+        self.assertIn(f"'{PKG_ID}.audio'",
+                      read("lib/services/audio_handler.dart"))
+        bindings = read("lib/utils/android/bindings.g.dart")
+        self.assertIn(f"`{PKG_ID}.AndroidHelper`", bindings)
+        self.assertIn(f"r'{CODE_PATH}/AndroidHelper'", bindings)
+        self.assertIn(f"r'L{CODE_PATH}/AndroidHelper;'", bindings)
+        self.assertIn(f"'{PKG_ID}.AndroidHelper'", read("tool/jnigen/jnigen.dart"))
+
+        constants = read("lib/common/constants.dart")
+        self.assertIn("appName = 'PiliSuper'", constants)
+        self.assertIn("https://github.com/FRBLanApps/PiliSuper", constants)
+        self.assertIn("FRBLanApps/PiliSuper/releases", read("lib/http/api.dart"))
+        self.assertIn("'pilisuper_settings_", read("lib/pages/backup.dart"))
+        self.assertIn("'pilisuper_${localFileName()}_'", read("lib/pages/export.dart"))
+        self.assertIn('"name": "PiliSuper"', read(".vscode/launch.json"))
+
+    def test_preserves_upstream_attribution(self):
+        run_rename()
+
+        gpl = read("lib/gpl_header.dart")
+        self.assertIn("This file is part of PiliPlus", gpl)
+        self.assertIn("created by bggRGjQaUbCoE", gpl)
+        self.assertIn("package:PiliSuper/", gpl)
+
+        readme = read("README.md")
+        self.assertIn("git clone https://github.com/bggRGjQaUbCoE/PiliPlus.git", readme)
+        self.assertIn("致敬原作者：[bggRGjQaUbCoE/PiliPlus]", readme)
+
+        issues = read(".github/ISSUE_TEMPLATE/bug.yml")
+        self.assertIn("https://github.com/FRBLanApps/PiliSuper/issues", issues)
+        self.assertIn(
+            "[上游的历史 issue](https://github.com/bggRGjQaUbCoE/PiliPlus/issues?q=is%3Aissue)",
+            issues)
+
+        self.assertIn("bggRGjQaUbCoE/audio_service.git", read("pubspec.yaml"))
+        self.assertIn("package:PiliPlus/", read("build/skipme.txt"))
+        self.assertIn("package:PiliPlus/", read(".dart_tool/skipme.txt"))
+        self.assertEqual(
+            Path("binary.png").read_bytes(),
+            b"\x89PNG\r\n\x1a\n\xff\xfe\x00piliplus")
+        self.assertEqual(
+            Path("crlf.txt").read_bytes(),
+            b"id=org.frblanapps.pilisuper\r\nimport 'package:PiliSuper/x.dart';\r\n")
+
+    def test_rename_is_idempotent(self):
+        run_rename()
+        snapshot = tree_snapshot()
+        run_rename()
+        self.assertEqual(tree_snapshot(), snapshot)
+
+
+class DisplayNameOnlyTests(RenameSandbox):
+    def test_bundle_id_untouched_when_pkg_id_unchanged(self):
+        run_rename("--pkg-id", "com.example.piliplus")
+
+        gradle = read("android/app/build.gradle.kts")
+        self.assertIn('namespace = "com.example.piliplus"', gradle)
+        self.assertIn('applicationId = "com.example.piliplus"', gradle)
+        self.assertIn(f'package="com.example.piliplus"',
+                      read("android/app/src/main/AndroidManifest.xml"))
+
+        # 大小写混合的旧 ID 与二进制名同现一文件时，只有后者被替换。
+        linux_cmake = read("linux/CMakeLists.txt")
+        self.assertIn('set(APPLICATION_ID "com.example.piliplus")', linux_cmake)
+        self.assertIn('set(BINARY_NAME "pilisuper")', linux_cmake)
+        self.assertIn("share/com.example.PiliPlus",
+                      read("assets/linux/DEBIAN/postrm"))
+
+        self.assertIn('<string name="app_name">PiliSuper</string>',
+                      read("android/app/src/main/res/values/string.xml"))
+        self.assertIn("appName = 'PiliSuper'", read("lib/common/constants.dart"))
+        self.assertTrue(Path(
+            "android/app/src/main/java/com/example/piliplus/AndroidHelper.java").is_file())
+        self.assertTrue(Path("assets/linux/com.example.piliplus.desktop").is_file())
+        self.assertIn("FRBLanApps/PiliSuper/releases", read("lib/http/api.dart"))
+
+
+class ValidationTests(RenameSandbox):
+    def test_reserved_word_package_rejected(self):
+        with self.assertRaises(SystemExit):
+            run_rename("--pkg-id", "com.pili.super")
+        self.assertIn("name: PiliPlus", read("pubspec.yaml"))
+
+    def test_invalid_segment_package_rejected(self):
+        with self.assertRaises(SystemExit):
+            run_rename("--pkg-id", "org.frblanapps.pili+super")
+        self.assertIn("name: PiliPlus", read("pubspec.yaml"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

`rename.py` 是构建流程中的改名步骤（源码树刻意保留上游标识以减少合并冲突），但改名覆盖不全面。在临时工作区实际运行旧脚本（本机 + dart CLI CI 等价环境）验证，确认以下全部漏改：

| 类别 | 漏改项 |
|---|---|
| Bundle ID | gradle `namespace`、manifest `package=`、shortcuts/MainActivity 的 `.SHORTCUT` action、java/kotlin **源码目录未移动**、通知渠道 ID、JNI 绑定（点+斜杠）、jnigen 配置、macOS `PRODUCT_BUNDLE_IDENTIFIER`、linux `APPLICATION_ID`、desktop `StartupWMClass` 与**文件名本身** |
| 显示名 | `string.xml`（main+debug）、gradle resValue、intent-filter label、macOS `PRODUCT_NAME`、`constants.dart` 的 `appName`（应用内显示名）、desktop `Name=`、DEBIAN 脚本、`.vscode/launch.json` |
| 二进制名 | linux/windows `BINARY_NAME`、`project()`、exe 名/窗口标题/Runner.rc、macOS `piliplus.app`、WebDAV 备份与导出文件名前缀 |
| 其他 | 更新检查 URL 指向**上游 PiliPlus 的 releases**；本机 util-linux `rename` 撞名导致脚本崩溃 |

根因：旧脚本只替换斜杠形式 `com/example/piliplus`（原生文件全是点分形式，零命中）；依赖的 dart `rename` CLI 默认只改 Android+iOS、不支持 `.kts` namespace、会把 `@string/app_name` 破坏性替换成字面量。

## 修复

- **`rename.py` 重写为自足实现**（不再依赖外部 CLI）：剪枝遍历 + 五步替换（Dart 包名含 patch 内容改写 / Bundle ID 点分+斜杠+大小写变体+目录移动+文件改名 / 显示名 / 二进制名 / 仓库引用）；身份区间保护防止误伤 `bggRGjQaUbCoE/PiliPlus` 这类上游引用；GPL 头、上游 issue 链接、git 依赖 URL、README 致谢全部保留；无换行转换读写（CRLF/patch 安全）
- **包名全平台统一为 `org.frblanapps.pilisuper`**：`com.pili.super` 含 Java/Kotlin 保留字 `super`，不能作 namespace/源码包；新增包名合法性校验，保留字直接报错。`packaging.py` / `build.yml` / README 同步对齐（保留 `com.pili.super` 的 legacy 打包映射）
- **删除 CI 中 5 处无用的 `dart pub global activate rename` 步骤**
- **新增回归测试** `tool/build/tests/test_rename_script.py`（全平台覆盖、署名保留、幂等性、ID 保护、保留字拒绝）

## 验证

- 26/26 测试通过（新增 6 个，已有 20 个无回归）
- 真实项目树端到端运行：旧标识清零，残留全部为故意保留的上游署名类；二次运行零文件变化（幂等）

## ⚠️ 破坏性变更

applicationId 从 `com.pili.super` 变为 `org.frblanapps.pilisuper`：已安装用户（com.pili.super）不会收到覆盖更新，会作为新应用安装；Linux 数据目录与 `piliplus_` 前缀的 WebDAV 备份文件同理（老备份需手动改名才能被新版本识别）。